### PR TITLE
銀行引落の「引落日」項目の表示を手動入力に変更

### DIFF
--- a/src/components/calendar/TransactionModal.tsx
+++ b/src/components/calendar/TransactionModal.tsx
@@ -21,7 +21,7 @@ import {
   validateUsage
 } from '@/lib/utils/validation';
 import { formatJapaneseDate, formatDateISO } from '@/lib/utils/dateUtils';
-import { calculateCardPaymentDate, calculateBankPaymentDate } from '@/lib/utils/paymentCalc';
+import { calculateCardPaymentDate } from '@/lib/utils/paymentCalc';
 
 export interface TransactionModalProps {
   isOpen: boolean;
@@ -103,7 +103,7 @@ export function TransactionModal({
           cardId: cards.length === 1 ? cards[0]?.id ?? '' : '',
           bankId: banks.length === 1 ? banks[0]?.id ?? '' : '',
           scheduledPayDate: formatDateISO(selectedDate),
-          isScheduleEditable: false,
+          isScheduleEditable: defaultPaymentType === 'bank',
           memo: ''
         });
       }
@@ -136,10 +136,10 @@ export function TransactionModal({
         }));
       }
     } else if (formData.paymentType === 'bank') {
-      const result = calculateBankPaymentDate(selectedDate, true);
+      // For bank payments, use the selected date directly (no automatic adjustment)
       setFormData(prev => ({
         ...prev,
-        scheduledPayDate: formatDateISO(result.scheduledPayDate)
+        scheduledPayDate: formatDateISO(selectedDate)
       }));
     }
   }, [formData.paymentType, formData.cardId, selectedDate, cards, isOpen, formData.isScheduleEditable]);
@@ -305,7 +305,7 @@ export function TransactionModal({
                   type="radio"
                   value="bank"
                   checked={formData.paymentType === 'bank'}
-                  onChange={() => setFormData(prev => ({ ...prev, paymentType: 'bank', isScheduleEditable: false }))}
+                  onChange={() => setFormData(prev => ({ ...prev, paymentType: 'bank', isScheduleEditable: true }))}
                   disabled={isFormDisabled}
                   className="mr-2"
                 />
@@ -412,7 +412,7 @@ export function TransactionModal({
               <p className="mt-1 text-xs text-gray-500">
                 {formData.paymentType === 'card' 
                   ? 'カードの設定に基づいて自動計算されます'
-                  : '取引日と同日（休日の場合は翌営業日）に設定されます'}
+                  : '銀行引落は手動で日付を入力してください'}
               </p>
             )}
           </div>

--- a/src/lib/database/operations.ts
+++ b/src/lib/database/operations.ts
@@ -350,11 +350,8 @@ export class TransactionOperations {
         const paymentResult = calculateCardPaymentDate(transactionDate, card);
         scheduledPayDate = paymentResult.scheduledPayDate.getTime();
       } else {
-        // Bank payment - calculate based on transaction date
-        const { calculateBankPaymentDate } = await import('@/lib/utils/paymentCalc');
-        const transactionDate = new Date(validatedData.date);
-        const paymentResult = calculateBankPaymentDate(transactionDate, true);
-        scheduledPayDate = paymentResult.scheduledPayDate.getTime();
+        // Bank payment - use transaction date directly (no automatic adjustment)
+        scheduledPayDate = validatedData.date;
         
         // Validate bank exists
         const bank = await this.db.banks.get(validatedData.bankId!);
@@ -592,7 +589,7 @@ export class TransactionOperations {
       
       // Recalculate scheduled payment date if payment method changes and not manually edited
       if (updates.paymentType && !updates.isScheduleEditable) {
-        const { calculateCardPaymentDate, calculateBankPaymentDate } = await import('@/lib/utils/paymentCalc');
+        const { calculateCardPaymentDate } = await import('@/lib/utils/paymentCalc');
         const transactionDate = new Date(updates.date || existing.date);
         
         if (updates.paymentType === 'card' && updates.cardId) {
@@ -602,8 +599,8 @@ export class TransactionOperations {
             updates.scheduledPayDate = result.scheduledPayDate.getTime();
           }
         } else if (updates.paymentType === 'bank') {
-          const result = calculateBankPaymentDate(transactionDate, true);
-          updates.scheduledPayDate = result.scheduledPayDate.getTime();
+          // For bank payments, use transaction date directly (no automatic adjustment)
+          updates.scheduledPayDate = transactionDate.getTime();
         }
       }
       


### PR DESCRIPTION
Fixes #25

Changed bank withdrawal date from automatic (business day adjustment) to manual input:

- Modified TransactionModal to default bank payments to manual input mode
- Changed database operations to use transaction date directly
- Removed automatic business day adjustment for bank withdrawals
- Updated UI messaging to reflect manual input requirement

🤖 Generated with [Claude Code](https://claude.ai/code)