### PR TITLE
feat: display Japanese holiday names in calendar

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -8,6 +8,7 @@ import {
   getMonthNameJP,
   formatDateISO,
   isSameDay,
+  getJapaneseHolidayName,
   type CalendarDay 
 } from '@/lib/utils/dateUtils';
 import { formatAmount } from '@/lib/utils/validation';
@@ -128,6 +129,7 @@ export function CalendarView({
           const daySchedule = scheduleByDate.get(dateKey) || [];
           const isSelected = selectedDate && isSameDay(calendarDay.date, selectedDate);
           const dayOfWeek = calendarDay.date.getDay();
+          const holidayName = calendarDay.isHoliday ? getJapaneseHolidayName(calendarDay.date) : null;
 
           return (
             <div
@@ -142,23 +144,25 @@ export function CalendarView({
                 calendarDay.isToday && 'bg-blue-100 font-semibold'
               )}
             >
-              {/* Date number */}
+              {/* Date number with holiday name */}
               <div className="flex items-center justify-between mb-1">
-                <span className={cn(
-                  'text-sm',
-                  !calendarDay.isCurrentMonth && 'text-gray-400',
-                  calendarDay.isToday && 'text-blue-700 font-bold',
-                  calendarDay.isWeekend && calendarDay.isCurrentMonth && !calendarDay.isToday && (
-                    dayOfWeek === 0 ? 'text-red-600' : 'text-blue-600'
-                  ),
-                  calendarDay.isHoliday && calendarDay.isCurrentMonth && 'text-red-600'
-                )}>
-                  {calendarDay.date.getDate()}
-                </span>
+                <div className="flex flex-col">
+                  <span className={cn(
+                    'text-sm leading-tight',
+                    !calendarDay.isCurrentMonth && 'text-gray-400',
+                    calendarDay.isToday && 'text-blue-700 font-bold',
+                    calendarDay.isWeekend && calendarDay.isCurrentMonth && !calendarDay.isToday && (
+                      dayOfWeek === 0 ? 'text-red-600' : 'text-blue-600'
+                    ),
+                    calendarDay.isHoliday && calendarDay.isCurrentMonth && 'text-red-600'
+                  )}>
+                    {calendarDay.date.getDate()}{holidayName && `（${holidayName}）`}
+                  </span>
+                </div>
                 
                 {/* Holiday indicator */}
                 {calendarDay.isHoliday && calendarDay.isCurrentMonth && (
-                  <span className="w-2 h-2 bg-red-500 rounded-full" />
+                  <span className="w-2 h-2 bg-red-500 rounded-full flex-shrink-0" />
                 )}
               </div>
 

--- a/src/lib/utils/dateUtils.ts
+++ b/src/lib/utils/dateUtils.ts
@@ -1,4 +1,4 @@
-import { isHoliday } from '@holiday-jp/holiday_jp';
+import { isHoliday, holidays } from '@holiday-jp/holiday_jp';
 
 /**
  * Japanese calendar and date utilities
@@ -98,6 +98,15 @@ export function isWeekend(date: Date): boolean {
  */
 export function isJapaneseHoliday(date: Date): boolean {
   return isHoliday(date);
+}
+
+/**
+ * Gets the Japanese holiday name for a given date
+ */
+export function getJapaneseHolidayName(date: Date): string | null {
+  const dateKey = formatDateISO(date);
+  const holiday = holidays[dateKey as keyof typeof holidays];
+  return holiday?.name || null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add Japanese holiday name display feature to calendar view
- Display format: {date}（{holiday_name}） for holidays like "11（山の日）"

## Implementation
- Added `getJapaneseHolidayName()` function in dateUtils.ts
- Updated CalendarView.tsx to display holiday names
- Utilizes existing @holiday-jp/holiday_jp library

## Testing
- Next.js build successful
- No breaking changes

Fixes #23

Generated with [Claude Code](https://claude.ai/code)