### PR TITLE
Fix bank payment display: hide blue area and show 銀行引落

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -71,6 +71,7 @@ export function CalendarView({
         type: 'payment',
         bankName: item.bankName,
         cardName: item.cardName,
+        paymentType: item.paymentType,
         amount: item.amount,
         storeName: item.storeName
       });
@@ -197,10 +198,10 @@ export function CalendarView({
                       'bg-orange-100 text-orange-800',
                       'border border-orange-200'
                     )}
-                    title={`${item.cardName} - ${item.storeName || '支払い'}: ${formatAmount(item.amount)}`}
+                    title={`${item.paymentType === 'bank' ? '銀行引落' : item.cardName} - ${item.storeName || '支払い'}: ${formatAmount(item.amount)}`}
                   >
                     <div className="truncate">
-                      {item.cardName}
+                      {item.paymentType === 'bank' ? '銀行引落' : item.cardName}
                     </div>
                     <div className="text-xs font-medium">
                       {formatAmount(item.amount)}

--- a/src/components/calendar/TransactionModal.tsx
+++ b/src/components/calendar/TransactionModal.tsx
@@ -418,7 +418,7 @@ export function TransactionModal({
           </div>
 
           {/* Payment preview */}
-          {selectedBank && (
+          {selectedBank && formData.paymentType === 'card' && (
             <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
               <p className="text-sm text-blue-700">
                 <strong>{selectedBank.name}</strong>


### PR DESCRIPTION
## Summary
- Hide blue-bordered payment preview area for bank withdrawals in transaction registration
- Update calendar view to show "銀行引落" for bank payments
- Card payments continue to show card names as before

## Test plan
- [x] Build process completed successfully
- [x] TypeScript compilation passed
- [ ] Manual testing of transaction registration screen
- [ ] Manual testing of calendar display

Fixes #21

🤖 Generated with [Claude Code](https://claude.ai/code)