### PR TITLE
カレンダー機能の改善

### DIFF
--- a/__tests__/types/calendar.test.ts
+++ b/__tests__/types/calendar.test.ts
@@ -189,7 +189,7 @@ describe('Calendar Types', () => {
   });
 
   describe('DayTotalData', () => {
-    it('完全なDayTotalDataが正しく構築されること', () => {
+    it('完全なDayTotalDataが正しく構築されること（分離データ対応）', () => {
       const transactions: Transaction[] = [
         {
           id: 'trans-1',
@@ -228,19 +228,27 @@ describe('Calendar Types', () => {
 
       const dayTotalData: DayTotalData = {
         date: '2024-02-15',
-        totalAmount: 20000,
+        totalAmount: 20000, // 総合計
+        transactionTotal: 15000, // 取引合計
+        scheduleTotal: 5000, // 引落予定合計
         transactionCount: 1,
         scheduleCount: 1,
         bankGroups,
         transactions,
         scheduleItems,
-        hasData: true
+        hasData: true,
+        hasTransactions: true, // 取引データあり
+        hasSchedule: true // 引落予定データあり
       };
 
       expect(dayTotalData.date).toBe('2024-02-15');
       expect(dayTotalData.totalAmount).toBe(20000);
+      expect(dayTotalData.transactionTotal).toBe(15000);
+      expect(dayTotalData.scheduleTotal).toBe(5000);
       expect(dayTotalData.transactionCount).toBe(1);
       expect(dayTotalData.scheduleCount).toBe(1);
+      expect(dayTotalData.hasTransactions).toBe(true);
+      expect(dayTotalData.hasSchedule).toBe(true);
       expect(dayTotalData.bankGroups).toHaveLength(1);
       expect(dayTotalData.transactions).toHaveLength(1);
       expect(dayTotalData.scheduleItems).toHaveLength(1);
@@ -251,22 +259,76 @@ describe('Calendar Types', () => {
       const dayTotalData: DayTotalData = {
         date: '2024-02-20',
         totalAmount: 0,
+        transactionTotal: 0,
+        scheduleTotal: 0,
         transactionCount: 0,
         scheduleCount: 0,
         bankGroups: [],
         transactions: [],
         scheduleItems: [],
-        hasData: false
+        hasData: false,
+        hasTransactions: false,
+        hasSchedule: false
       };
 
       expect(dayTotalData.date).toBe('2024-02-20');
       expect(dayTotalData.totalAmount).toBe(0);
+      expect(dayTotalData.transactionTotal).toBe(0);
+      expect(dayTotalData.scheduleTotal).toBe(0);
       expect(dayTotalData.transactionCount).toBe(0);
       expect(dayTotalData.scheduleCount).toBe(0);
+      expect(dayTotalData.hasTransactions).toBe(false);
+      expect(dayTotalData.hasSchedule).toBe(false);
       expect(dayTotalData.bankGroups).toHaveLength(0);
       expect(dayTotalData.transactions).toHaveLength(0);
       expect(dayTotalData.scheduleItems).toHaveLength(0);
       expect(dayTotalData.hasData).toBe(false);
+    });
+
+    it('取引データのみの場合のDayTotalDataが正しく構築されること', () => {
+      const dayTotalData: DayTotalData = {
+        date: '2024-02-25',
+        totalAmount: 12000,
+        transactionTotal: 12000,
+        scheduleTotal: 0,
+        transactionCount: 2,
+        scheduleCount: 0,
+        bankGroups: [],
+        transactions: [],
+        scheduleItems: [],
+        hasData: true,
+        hasTransactions: true,
+        hasSchedule: false
+      };
+
+      expect(dayTotalData.hasTransactions).toBe(true);
+      expect(dayTotalData.hasSchedule).toBe(false);
+      expect(dayTotalData.transactionTotal).toBe(12000);
+      expect(dayTotalData.scheduleTotal).toBe(0);
+      expect(dayTotalData.totalAmount).toBe(12000);
+    });
+
+    it('引落予定データのみの場合のDayTotalDataが正しく構築されること', () => {
+      const dayTotalData: DayTotalData = {
+        date: '2024-02-28',
+        totalAmount: 8000,
+        transactionTotal: 0,
+        scheduleTotal: 8000,
+        transactionCount: 0,
+        scheduleCount: 2,
+        bankGroups: [],
+        transactions: [],
+        scheduleItems: [],
+        hasData: true,
+        hasTransactions: false,
+        hasSchedule: true
+      };
+
+      expect(dayTotalData.hasTransactions).toBe(false);
+      expect(dayTotalData.hasSchedule).toBe(true);
+      expect(dayTotalData.transactionTotal).toBe(0);
+      expect(dayTotalData.scheduleTotal).toBe(8000);
+      expect(dayTotalData.totalAmount).toBe(8000);
     });
   });
 
@@ -304,20 +366,28 @@ describe('Calendar Types', () => {
         totalAmount: 20000,
         transactionCount: 2,
         scheduleCount: 1,
+        transactionTotal: 15000,
+        scheduleTotal: 5000,
         bankGroups: [],
         transactions: [],
         scheduleItems: [],
-        hasData: true
+        hasData: true,
+        hasTransactions: true,
+        hasSchedule: true
       });
       totals.set('2024-02-20', {
         date: '2024-02-20',
         totalAmount: 15000,
         transactionCount: 1,
         scheduleCount: 0,
+        transactionTotal: 15000,
+        scheduleTotal: 0,
         bankGroups: [],
         transactions: [],
         scheduleItems: [],
-        hasData: true
+        hasData: true,
+        hasTransactions: true,
+        hasSchedule: false
       });
 
       const result: CalendarTotalsResult = {
@@ -374,10 +444,14 @@ describe('Calendar Types', () => {
         totalAmount: 0,
         transactionCount: 0,
         scheduleCount: 0,
+        transactionTotal: 0,
+        scheduleTotal: 0,
         bankGroups: [],
         transactions: [],
         scheduleItems: [],
-        hasData: false
+        hasData: false,
+        hasTransactions: false,
+        hasSchedule: false
       };
 
       // ISO日付形式（YYYY-MM-DD）であることを確認

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -97,18 +97,24 @@ export function CalendarView({
           totalAmount: 0,
           transactionCount: 0,
           scheduleCount: 0,
+          transactionTotal: 0,
+          scheduleTotal: 0,
           bankGroups: [],
           transactions: [],
           scheduleItems: [],
-          hasData: false
+          hasData: false,
+          hasTransactions: false,
+          hasSchedule: false
         });
       }
       
       const dayTotal = totals.get(dateKey)!;
+      dayTotal.transactionTotal += transaction.amount;
       dayTotal.totalAmount += transaction.amount;
       dayTotal.transactionCount++;
       dayTotal.transactions.push(transaction);
       dayTotal.hasData = true;
+      dayTotal.hasTransactions = true;
     });
     
     // Process schedule items
@@ -122,18 +128,24 @@ export function CalendarView({
             totalAmount: 0,
             transactionCount: 0,
             scheduleCount: 0,
+            transactionTotal: 0,
+            scheduleTotal: 0,
             bankGroups: [],
             transactions: [],
             scheduleItems: [],
-            hasData: false
+            hasData: false,
+            hasTransactions: false,
+            hasSchedule: false
           });
         }
         
         const dayTotal = totals.get(dateKey)!;
+        dayTotal.scheduleTotal += item.amount;
         dayTotal.totalAmount += item.amount;
         dayTotal.scheduleCount++;
         dayTotal.scheduleItems.push(item);
         dayTotal.hasData = true;
+        dayTotal.hasSchedule = true;
       });
     }
     
@@ -244,20 +256,45 @@ export function CalendarView({
               <div className="flex-1 space-y-1">
                 {(() => {
                   const dayTotal = calculateDayTotals.get(dateKey);
-                  if (!dayTotal || dayTotal.totalAmount === 0) return null;
+                  if (!dayTotal || !dayTotal.hasData) return null;
                   
-                  return (
-                    <div 
-                      className="px-2 py-1 text-xs rounded cursor-pointer bg-blue-100 text-blue-900 hover:bg-blue-200 border border-blue-300 font-semibold"
-                      onClick={(e) => handleDayTotalClick(calendarDay, e)}
-                      title={`引落予定合計: ${formatAmount(dayTotal.totalAmount)} (取引${dayTotal.transactionCount}件、予定${dayTotal.scheduleCount}件)`}
-                    >
-                      <div className="text-center">
-                        <div className="text-xs font-bold">引落予定</div>
-                        <div className="text-sm font-bold">{formatAmount(dayTotal.totalAmount)}</div>
+                  const items = [];
+                  
+                  // 取引データがある場合
+                  if (dayTotal.hasTransactions && dayTotal.transactionTotal > 0) {
+                    items.push(
+                      <div 
+                        key="transaction"
+                        className="px-2 py-1 text-xs rounded cursor-pointer bg-green-100 text-green-900 hover:bg-green-200 border border-green-300 font-semibold"
+                        onClick={(e) => handleDayTotalClick(calendarDay, e)}
+                        title={`取引合計: ${formatAmount(dayTotal.transactionTotal)} (取引${dayTotal.transactionCount}件)`}
+                      >
+                        <div className="text-center">
+                          <div className="text-xs font-bold">取引合計</div>
+                          <div className="text-sm font-bold">{formatAmount(dayTotal.transactionTotal)}</div>
+                        </div>
                       </div>
-                    </div>
-                  );
+                    );
+                  }
+                  
+                  // 引落予定データがある場合
+                  if (dayTotal.hasSchedule && dayTotal.scheduleTotal > 0) {
+                    items.push(
+                      <div 
+                        key="schedule"
+                        className="px-2 py-1 text-xs rounded cursor-pointer bg-blue-100 text-blue-900 hover:bg-blue-200 border border-blue-300 font-semibold"
+                        onClick={(e) => handleDayTotalClick(calendarDay, e)}
+                        title={`引落予定合計: ${formatAmount(dayTotal.scheduleTotal)} (予定${dayTotal.scheduleCount}件)`}
+                      >
+                        <div className="text-center">
+                          <div className="text-xs font-bold">引落予定</div>
+                          <div className="text-sm font-bold">{formatAmount(dayTotal.scheduleTotal)}</div>
+                        </div>
+                      </div>
+                    );
+                  }
+                  
+                  return items;
                 })()}
               </div>
             </div>
@@ -268,6 +305,10 @@ export function CalendarView({
       {/* Legend */}
       <div className="p-4 border-t border-gray-200 bg-gray-50">
         <div className="flex flex-wrap gap-4 text-xs">
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 bg-green-100 border border-green-300 rounded" />
+            <span className="text-gray-600">取引合計</span>
+          </div>
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 bg-blue-100 border border-blue-300 rounded" />
             <span className="text-gray-600">引落予定</span>

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -45,13 +45,18 @@ export interface PaymentItem {
  */
 export interface DayTotalData {
   date: string; // ISO date string (YYYY-MM-DD)
-  totalAmount: number;
+  totalAmount: number; // 総合計（互換性のため保持）
   transactionCount: number;
   scheduleCount: number;
+  // 分離されたデータ
+  transactionTotal: number; // 取引合計
+  scheduleTotal: number; // 引落予定合計
   bankGroups: BankGroup[];
   transactions: Transaction[];
   scheduleItems: any[]; // From schedule data
   hasData: boolean;
+  hasTransactions: boolean; // 取引データがあるかどうか
+  hasSchedule: boolean; // 引落予定データがあるかどうか
 }
 
 /**


### PR DESCRIPTION
- 取引データと引落予定データを分離して表示する機能を追加
- DayTotalModalで取引と引落予定の合計金額を個別に表示
- CalendarViewでのデータ表示ロジックを整理し、クリック可能な要素を追加
- テストコードを更新し、分離されたデータに対応

Subprojectのコミットを更新し、状態を「dirty」に変更。