### PR TITLE
カレンダー機能の改善

### DIFF
--- a/__tests__/components/calendar/BaseModal.test.tsx
+++ b/__tests__/components/calendar/BaseModal.test.tsx
@@ -1,0 +1,420 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BaseModal, BaseModalFooter } from '@/components/calendar/BaseModal';
+
+describe('BaseModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    title: 'テストモーダル',
+    children: <div>テストコンテンツ</div>
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // モーダル用のbody styleリセット
+    document.body.style.overflow = 'unset';
+  });
+
+  afterEach(() => {
+    // テスト後にbody styleをクリーンアップ
+    document.body.style.overflow = 'unset';
+  });
+
+  describe('基本レンダリング', () => {
+    it('モーダルが正常に表示されること', () => {
+      render(<BaseModal {...defaultProps} />);
+      
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('テストモーダル')).toBeInTheDocument();
+      expect(screen.getByText('テストコンテンツ')).toBeInTheDocument();
+    });
+
+    it('isOpenがfalseのときにモーダルが表示されないこと', () => {
+      render(<BaseModal {...defaultProps} isOpen={false} />);
+      
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(screen.queryByText('テストモーダル')).not.toBeInTheDocument();
+    });
+
+    it('タイトルが正しく表示されること', () => {
+      render(<BaseModal {...defaultProps} title="カスタムタイトル" />);
+      
+      const titleElement = screen.getByText('カスタムタイトル');
+      expect(titleElement).toBeInTheDocument();
+      expect(titleElement).toHaveAttribute('id', 'modal-title');
+    });
+
+    it('子要素が正しく表示されること', () => {
+      const customContent = (
+        <div>
+          <p>カスタムコンテンツ</p>
+          <button>テストボタン</button>
+        </div>
+      );
+      
+      render(<BaseModal {...defaultProps} children={customContent} />);
+      
+      expect(screen.getByText('カスタムコンテンツ')).toBeInTheDocument();
+      expect(screen.getByText('テストボタン')).toBeInTheDocument();
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('適切なARIA属性が設定されていること', () => {
+      render(<BaseModal {...defaultProps} />);
+      
+      const modal = screen.getByRole('dialog');
+      expect(modal).toHaveAttribute('aria-modal', 'true');
+      expect(modal).toHaveAttribute('aria-labelledby', 'modal-title');
+    });
+
+    it('閉じるボタンにaria-labelが設定されていること', () => {
+      render(<BaseModal {...defaultProps} />);
+      
+      const closeButton = screen.getByLabelText('閉じる');
+      expect(closeButton).toBeInTheDocument();
+    });
+
+    it('フォーカス管理が適切に行われること', () => {
+      render(<BaseModal {...defaultProps} />);
+      
+      const closeButton = screen.getByLabelText('閉じる');
+      expect(closeButton).toHaveClass('focus:outline-none', 'focus:ring-2', 'focus:ring-blue-500');
+    });
+  });
+
+  describe('モーダルサイズ', () => {
+    it('デフォルトサイズ（md）が適用されること', () => {
+      const { container } = render(<BaseModal {...defaultProps} />);
+      
+      const modalContent = container.querySelector('.max-w-md');
+      expect(modalContent).toBeInTheDocument();
+    });
+
+    it('smallサイズが適用されること', () => {
+      const { container } = render(<BaseModal {...defaultProps} size="sm" />);
+      
+      const modalContent = container.querySelector('.max-w-sm');
+      expect(modalContent).toBeInTheDocument();
+    });
+
+    it('largeサイズが適用されること', () => {
+      const { container } = render(<BaseModal {...defaultProps} size="lg" />);
+      
+      const modalContent = container.querySelector('.max-w-lg');
+      expect(modalContent).toBeInTheDocument();
+    });
+  });
+
+  describe('カスタムスタイリング', () => {
+    it('カスタムclassNameが適用されること', () => {
+      const { container } = render(<BaseModal {...defaultProps} className="custom-modal" />);
+      
+      const modalContent = container.querySelector('.custom-modal');
+      expect(modalContent).toBeInTheDocument();
+    });
+
+    it('カスタムheaderClassNameが適用されること', () => {
+      const { container } = render(<BaseModal {...defaultProps} headerClassName="custom-header" />);
+      
+      const headerElement = container.querySelector('.custom-header');
+      expect(headerElement).toBeInTheDocument();
+    });
+
+    it('カスタムbodyClassNameが適用されること', () => {
+      const { container } = render(<BaseModal {...defaultProps} bodyClassName="custom-body" />);
+      
+      const bodyElement = container.querySelector('.custom-body');
+      expect(bodyElement).toBeInTheDocument();
+    });
+  });
+
+  describe('閉じる操作', () => {
+    it('Escキーでモーダルが閉じること', async () => {
+      const onClose = jest.fn();
+      render(<BaseModal {...defaultProps} onClose={onClose} />);
+      
+      fireEvent.keyDown(document, { key: 'Escape' });
+      
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    it('バックドロップクリックでモーダルが閉じること', async () => {
+      const onClose = jest.fn();
+      render(<BaseModal {...defaultProps} onClose={onClose} />);
+      
+      const backdrop = screen.getByRole('dialog');
+      fireEvent.click(backdrop);
+      
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    it('モーダル内のコンテンツクリックでは閉じないこと', async () => {
+      const onClose = jest.fn();
+      render(<BaseModal {...defaultProps} onClose={onClose} />);
+      
+      const content = screen.getByText('テストコンテンツ');
+      fireEvent.click(content);
+      
+      // 少し待ってもonCloseが呼ばれないことを確認
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('閉じるボタンでモーダルが閉じること', async () => {
+      const onClose = jest.fn();
+      render(<BaseModal {...defaultProps} onClose={onClose} />);
+      
+      const closeButton = screen.getByLabelText('閉じる');
+      fireEvent.click(closeButton);
+      
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('ボディスクロール制御', () => {
+    it('モーダルが開いているときにボディのスクロールが無効化されること', () => {
+      render(<BaseModal {...defaultProps} />);
+      
+      expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    it('モーダルが閉じられるときにボディのスクロールが復元されること', () => {
+      const { unmount } = render(<BaseModal {...defaultProps} />);
+      
+      unmount();
+      
+      expect(document.body.style.overflow).toBe('unset');
+    });
+  });
+
+  describe('フッター表示', () => {
+    it('footerChildrenが提供されたときにフッターが表示されること', () => {
+      const footerContent = <button>フッターボタン</button>;
+      
+      render(<BaseModal {...defaultProps} footerChildren={footerContent} />);
+      
+      expect(screen.getByText('フッターボタン')).toBeInTheDocument();
+    });
+
+    it('footerChildrenが提供されないときにフッターが表示されないこと', () => {
+      const { container } = render(<BaseModal {...defaultProps} />);
+      
+      const footer = container.querySelector('.border-t.border-gray-200.bg-gray-50');
+      expect(footer).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('BaseModalFooter', () => {
+  const defaultFooterProps = {
+    onClose: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('基本レンダリング', () => {
+    it('デフォルトの閉じるボタンが表示されること', () => {
+      render(<BaseModalFooter {...defaultFooterProps} />);
+      
+      expect(screen.getByText('閉じる')).toBeInTheDocument();
+    });
+
+    it('プライマリアクションが表示されること', () => {
+      const primaryAction = {
+        label: '保存',
+        onClick: jest.fn(),
+        variant: 'primary' as const
+      };
+      
+      render(<BaseModalFooter {...defaultFooterProps} primaryAction={primaryAction} />);
+      
+      expect(screen.getByText('保存')).toBeInTheDocument();
+    });
+
+    it('セカンダリアクションが表示されること', () => {
+      const secondaryAction = {
+        label: 'キャンセル',
+        onClick: jest.fn(),
+        variant: 'secondary' as const
+      };
+      
+      render(<BaseModalFooter {...defaultFooterProps} secondaryAction={secondaryAction} />);
+      
+      expect(screen.getByText('キャンセル')).toBeInTheDocument();
+    });
+  });
+
+  describe('ボタンスタイリング', () => {
+    it('プライマリボタンが正しいスタイルを持つこと', () => {
+      const primaryAction = {
+        label: '保存',
+        onClick: jest.fn(),
+        variant: 'primary' as const
+      };
+      
+      render(<BaseModalFooter {...defaultFooterProps} primaryAction={primaryAction} />);
+      
+      const button = screen.getByText('保存');
+      expect(button).toHaveClass('bg-blue-600', 'text-white');
+    });
+
+    it('dangerボタンが正しいスタイルを持つこと', () => {
+      const primaryAction = {
+        label: '削除',
+        onClick: jest.fn(),
+        variant: 'danger' as const
+      };
+      
+      render(<BaseModalFooter {...defaultFooterProps} primaryAction={primaryAction} />);
+      
+      const button = screen.getByText('削除');
+      expect(button).toHaveClass('bg-red-600', 'text-white');
+    });
+
+    it('disabledボタンが正しいスタイルを持つこと', () => {
+      const primaryAction = {
+        label: '保存',
+        onClick: jest.fn(),
+        variant: 'primary' as const,
+        disabled: true
+      };
+      
+      render(<BaseModalFooter {...defaultFooterProps} primaryAction={primaryAction} />);
+      
+      const button = screen.getByText('保存');
+      expect(button).toHaveClass('bg-gray-300', 'text-gray-500', 'cursor-not-allowed');
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe('ボタンクリック動作', () => {
+    it('プライマリアクションクリックが正常に動作すること', async () => {
+      const onClick = jest.fn();
+      const primaryAction = {
+        label: '保存',
+        onClick,
+        variant: 'primary' as const
+      };
+      
+      render(<BaseModalFooter {...defaultFooterProps} primaryAction={primaryAction} />);
+      
+      const button = screen.getByText('保存');
+      fireEvent.click(button);
+      
+      await waitFor(() => {
+        expect(onClick).toHaveBeenCalled();
+      });
+    });
+
+    it('セカンダリアクションクリックが正常に動作すること', async () => {
+      const onClick = jest.fn();
+      const secondaryAction = {
+        label: 'キャンセル',
+        onClick,
+        variant: 'secondary' as const
+      };
+      
+      render(<BaseModalFooter {...defaultFooterProps} secondaryAction={secondaryAction} />);
+      
+      const button = screen.getByText('キャンセル');
+      fireEvent.click(button);
+      
+      await waitFor(() => {
+        expect(onClick).toHaveBeenCalled();
+      });
+    });
+
+    it('デフォルトの閉じるボタンクリックが正常に動作すること', async () => {
+      const onClose = jest.fn();
+      
+      render(<BaseModalFooter onClose={onClose} />);
+      
+      const button = screen.getByText('閉じる');
+      fireEvent.click(button);
+      
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    it('disabledボタンがクリックされないこと', async () => {
+      const onClick = jest.fn();
+      const primaryAction = {
+        label: '保存',
+        onClick,
+        variant: 'primary' as const,
+        disabled: true
+      };
+      
+      render(<BaseModalFooter {...defaultFooterProps} primaryAction={primaryAction} />);
+      
+      const button = screen.getByText('保存');
+      fireEvent.click(button);
+      
+      // disabled状態ではonClickが呼ばれない
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('複数ボタン組み合わせ', () => {
+    it('プライマリとセカンダリの両方のアクションが表示されること', () => {
+      const primaryAction = {
+        label: '保存',
+        onClick: jest.fn(),
+        variant: 'primary' as const
+      };
+      
+      const secondaryAction = {
+        label: 'キャンセル',
+        onClick: jest.fn(),
+        variant: 'secondary' as const
+      };
+      
+      render(<BaseModalFooter 
+        {...defaultFooterProps} 
+        primaryAction={primaryAction}
+        secondaryAction={secondaryAction}
+      />);
+      
+      expect(screen.getByText('保存')).toBeInTheDocument();
+      expect(screen.getByText('キャンセル')).toBeInTheDocument();
+      // デフォルトの閉じるボタンは表示されない
+      expect(screen.queryByText('閉じる')).not.toBeInTheDocument();
+    });
+
+    it('ボタンが正しい順序で表示されること', () => {
+      const primaryAction = {
+        label: '保存',
+        onClick: jest.fn(),
+        variant: 'primary' as const
+      };
+      
+      const secondaryAction = {
+        label: 'キャンセル',
+        onClick: jest.fn(),
+        variant: 'secondary' as const
+      };
+      
+      const { container } = render(<BaseModalFooter 
+        {...defaultFooterProps} 
+        primaryAction={primaryAction}
+        secondaryAction={secondaryAction}
+      />);
+      
+      const buttons = container.querySelectorAll('button');
+      expect(buttons[0]).toHaveTextContent('キャンセル'); // セカンダリが先
+      expect(buttons[1]).toHaveTextContent('保存'); // プライマリが後
+    });
+  });
+});

--- a/__tests__/components/calendar/DayTotalModal.test.tsx
+++ b/__tests__/components/calendar/DayTotalModal.test.tsx
@@ -133,8 +133,8 @@ describe('DayTotalModal', () => {
       expect(screen.getAllByText('￥45,840').length).toBeGreaterThan(0);
       expect(screen.getByText('引落予定合計:')).toBeInTheDocument();
       expect(screen.getAllByText('￥5,000').length).toBeGreaterThan(0);
-      expect(screen.getByText('総合計:')).toBeInTheDocument();
-      expect(screen.getByText('￥50,840')).toBeInTheDocument();
+      // 新しい分離ダイアログ機能では総合計は表示されない
+      expect(screen.queryByText('総合計:')).not.toBeInTheDocument();
     });
 
     it('isOpenがfalseのときにモーダルが表示されないこと', () => {

--- a/__tests__/components/calendar/ScheduleModal.test.tsx
+++ b/__tests__/components/calendar/ScheduleModal.test.tsx
@@ -1,0 +1,451 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ScheduleModal } from '@/components/calendar/ScheduleModal';
+import { ScheduleItem, Bank, Card } from '@/types/database';
+
+describe('ScheduleModal', () => {
+  const mockBanks: Bank[] = [
+    {
+      id: 'bank-1',
+      name: 'SBIネット銀行',
+      memo: '',
+      createdAt: Date.now()
+    },
+    {
+      id: 'bank-2',
+      name: 'りそな銀行',
+      memo: '',
+      createdAt: Date.now()
+    }
+  ];
+
+  const mockCards: Card[] = [
+    {
+      id: 'card-1',
+      name: 'PayPayカード',
+      bankId: 'bank-1',
+      closingDay: '15',
+      paymentDay: '27',
+      paymentMonthShift: 1,
+      adjustWeekend: true,
+      memo: '',
+      createdAt: Date.now()
+    },
+    {
+      id: 'card-2',
+      name: '楽天カード',
+      bankId: 'bank-2',
+      closingDay: '月末',
+      paymentDay: '27',
+      paymentMonthShift: 1,
+      adjustWeekend: true,
+      memo: '',
+      createdAt: Date.now()
+    }
+  ];
+
+  const mockScheduleItems: ScheduleItem[] = [
+    {
+      transactionId: 'schedule-1',
+      date: new Date(2024, 1, 15),
+      amount: 15000,
+      storeName: 'Amazon利用分',
+      usage: 'オンラインショッピング',
+      paymentType: 'card',
+      cardId: 'card-1',
+      cardName: 'PayPayカード',
+      bankName: 'SBIネット銀行'
+    },
+    {
+      transactionId: 'schedule-2',
+      date: new Date(2024, 1, 15),
+      amount: 22840,
+      storeName: '楽天市場利用分',
+      usage: 'ネットショッピング',
+      paymentType: 'card',
+      cardId: 'card-2',
+      cardName: '楽天カード',
+      bankName: 'りそな銀行'
+    },
+    {
+      transactionId: 'schedule-3',
+      date: new Date(2024, 1, 15),
+      amount: 8000,
+      storeName: '電力会社',
+      usage: '電気代',
+      paymentType: 'bank',
+      bankName: 'SBIネット銀行'
+    }
+  ];
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    selectedDate: new Date(2024, 1, 15),
+    scheduleItems: mockScheduleItems,
+    banks: mockBanks,
+    cards: mockCards
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('基本レンダリング', () => {
+    it('モーダルが正常に表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('引落予定 - 2024年2月15日')).toBeInTheDocument();
+      expect(screen.getByText('引落予定')).toBeInTheDocument();
+      expect(screen.getByText('予定されている引落し')).toBeInTheDocument();
+    });
+
+    it('isOpenがfalseのときにモーダルが表示されないこと', () => {
+      render(<ScheduleModal {...defaultProps} isOpen={false} />);
+      
+      expect(screen.queryByText('引落予定 - 2024年2月15日')).not.toBeInTheDocument();
+    });
+
+    it('引落予定データがないときにモーダルが表示されないこと', () => {
+      render(<ScheduleModal {...defaultProps} scheduleItems={[]} />);
+      
+      expect(screen.queryByText('引落予定 - 2024年2月15日')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('青色テーマの適用', () => {
+    it('ヘッダーが青色背景で表示されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      const header = container.querySelector('.bg-blue-50.border-blue-200');
+      expect(header).toBeInTheDocument();
+    });
+
+    it('引落予定サマリーが青色テーマで表示されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      const summary = container.querySelector('.bg-blue-50.border-blue-200');
+      expect(summary).toBeInTheDocument();
+      expect(summary?.textContent).toContain('引落予定');
+    });
+
+    it('銀行セクションヘッダーが青色で表示されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      const bankHeaders = container.querySelectorAll('.bg-blue-100.border-b.border-blue-200');
+      expect(bankHeaders.length).toBeGreaterThan(0);
+    });
+
+    it('引落予定項目が青色ボーダーで表示されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      const scheduleItems = container.querySelectorAll('.border-blue-200');
+      expect(scheduleItems.length).toBeGreaterThan(0);
+    });
+
+    it('予定バッジが青色で表示されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      const badges = container.querySelectorAll('.bg-blue-100.text-blue-800');
+      expect(badges.length).toBeGreaterThan(0);
+      
+      // 予定バッジが正しく表示されていることを確認
+      const scheduleBadges = screen.getAllByText('予定');
+      expect(scheduleBadges.length).toBe(3);
+    });
+  });
+
+  describe('引落予定データサマリー', () => {
+    it('正しい合計金額が表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      // 15,000 + 22,840 + 8,000 = 45,840
+      expect(screen.getByText('￥45,840')).toBeInTheDocument();
+    });
+
+    it('正しい予定件数が表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('3件の予定')).toBeInTheDocument();
+    });
+
+    it('引落予定の説明文が表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('予定されている引落し')).toBeInTheDocument();
+    });
+  });
+
+  describe('銀行別グループ化表示', () => {
+    it('銀行別にグループ化されて表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('SBIネット銀行')).toBeInTheDocument();
+      expect(screen.getByText('りそな銀行')).toBeInTheDocument();
+    });
+
+    it('銀行ごとの合計金額が正しく表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      // SBIネット銀行: PayPayカード(15,000) + 銀行引落(8,000) = 23,000
+      expect(screen.getByText('￥23,000')).toBeInTheDocument();
+      
+      // りそな銀行: 楽天カード(22,840) = 22,840 (重複があるため getAllByText を使用)
+      const amounts22840 = screen.getAllByText('￥22,840');
+      expect(amounts22840.length).toBeGreaterThan(0);
+    });
+
+    it('銀行ごとの予定件数が正しく表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      // SBIネット銀行は2件、りそな銀行は1件
+      const bankHeaders = screen.getAllByText(/\d+件/);
+      expect(bankHeaders.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('カード名と支払い方法表示', () => {
+    it('カード支払いでカード名が表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('PayPayカード')).toBeInTheDocument();
+      expect(screen.getByText('楽天カード')).toBeInTheDocument();
+    });
+
+    it('銀行引落で「自動引き落とし」が表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('自動引き落とし')).toBeInTheDocument();
+    });
+
+    it('すべての予定に「予定」バッジが表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      const badges = screen.getAllByText('予定');
+      expect(badges.length).toBe(3);
+    });
+  });
+
+  describe('店舗情報とusage表示', () => {
+    it('店舗名が正しく表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('Amazon利用分')).toBeInTheDocument();
+      expect(screen.getByText('楽天市場利用分')).toBeInTheDocument();
+      expect(screen.getByText('電力会社')).toBeInTheDocument();
+    });
+
+    it('用途（usage）が正しく表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      const usageLabels = screen.getAllByText('用途:');
+      expect(usageLabels.length).toBeGreaterThan(0);
+      expect(screen.getByText('オンラインショッピング')).toBeInTheDocument();
+      expect(screen.getByText('ネットショッピング')).toBeInTheDocument();
+      expect(screen.getByText('電気代')).toBeInTheDocument();
+    });
+
+    it('店舗情報が適切なフォーマットで表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      // 店舗情報は「店舗: 店舗名」の形式で表示
+      expect(screen.getByText('店舗:')).toBeInTheDocument();
+    });
+
+    it('カード名の右に店舗情報が表示されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      // カード名と店舗名が同じ行に表示されていることを確認
+      const cardNameElements = container.querySelectorAll('.font-medium.text-gray-900');
+      expect(cardNameElements.length).toBeGreaterThan(0);
+      
+      // 店舗情報が適切な位置に表示されることを確認
+      const storeInfoElements = screen.getAllByText(/• /);
+      expect(storeInfoElements.length).toBeGreaterThan(0);
+    });
+
+    it('店舗名やusageがない項目でも正常に表示されること', () => {
+      const scheduleWithoutStoreAndUsage = {
+        ...mockScheduleItems[0],
+        storeName: '',
+        usage: ''
+      };
+      
+      render(<ScheduleModal 
+        {...defaultProps} 
+        scheduleItems={[scheduleWithoutStoreAndUsage]}
+      />);
+      
+      expect(screen.getByText('PayPayカード')).toBeInTheDocument();
+      // 店舗名やusageがない場合は対応するセクションが表示されない
+      expect(screen.queryByText('店舗:')).not.toBeInTheDocument();
+      expect(screen.queryByText('用途:')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('表示のみ機能（編集不可）', () => {
+    it('引落予定項目がクリック不可であること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      // カーソルポインターがないことを確認
+      const scheduleItems = container.querySelectorAll('.px-4.py-3');
+      scheduleItems.forEach(item => {
+        expect(item).not.toHaveClass('cursor-pointer');
+      });
+    });
+
+    it('引落予定項目に編集アイコンが表示されないこと', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      // 編集アイコン（鉛筆アイコン）がないことを確認
+      const editIcons = container.querySelectorAll('path[d*="15.232 5.232l3.536 3.536"]');
+      expect(editIcons.length).toBe(0);
+    });
+
+    it('ホバー効果が控えめに適用されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      // hover:bg-blue-25というクラスが適用されていることを確認
+      const scheduleItems = container.querySelectorAll('.hover\\:bg-blue-25');
+      // 注: この例では特別なホバークラスを使用していないため、
+      // 実際の実装に応じて調整が必要
+    });
+  });
+
+  describe('情報ガイド', () => {
+    it('引落予定についての情報ガイドが表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('引落予定について:')).toBeInTheDocument();
+      expect(screen.getByText('これらは取引に基づいて自動計算された引落予定です')).toBeInTheDocument();
+      expect(screen.getByText('実際の引落日は銀行の営業日により前後する場合があります')).toBeInTheDocument();
+      expect(screen.getByText('店舗情報と用途が登録されている場合に表示されます')).toBeInTheDocument();
+      expect(screen.getByText('引落予定は表示のみで、直接編集はできません')).toBeInTheDocument();
+    });
+
+    it('情報ガイドに情報アイコンが表示されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      const infoIcon = container.querySelector('.text-blue-500');
+      expect(infoIcon).toBeInTheDocument();
+    });
+  });
+
+  describe('データが空の場合', () => {
+    it('引落予定データがない場合のメッセージが表示されること', () => {
+      render(<ScheduleModal {...defaultProps} scheduleItems={[]} />);
+      
+      // 引落予定データがない場合はモーダル自体が表示されない
+      expect(screen.queryByText('この日の引落予定はありません')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('個別金額表示', () => {
+    it('各引落予定の金額が正しく表示されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      expect(screen.getByText('￥15,000')).toBeInTheDocument();
+      // 22,840円は複数回表示される可能性があるため getAllByText を使用
+      const amounts22840 = screen.getAllByText('￥22,840');
+      expect(amounts22840.length).toBeGreaterThan(0);
+      expect(screen.getByText('￥8,000')).toBeInTheDocument();
+    });
+  });
+
+  describe('複数銀行の処理', () => {
+    it('異なる銀行のカードが正しくグループ化されること', () => {
+      render(<ScheduleModal {...defaultProps} />);
+      
+      // 両方の銀行が表示される
+      expect(screen.getByText('SBIネット銀行')).toBeInTheDocument();
+      expect(screen.getByText('りそな銀行')).toBeInTheDocument();
+      
+      // 対応するカードが正しい銀行下に表示される
+      expect(screen.getByText('PayPayカード')).toBeInTheDocument();
+      expect(screen.getByText('楽天カード')).toBeInTheDocument();
+    });
+  });
+
+  describe('閉じる操作', () => {
+    it('フッターの閉じるボタンが正常に動作すること', async () => {
+      const onClose = jest.fn();
+      render(<ScheduleModal {...defaultProps} onClose={onClose} />);
+      
+      const closeButton = screen.getByText('閉じる');
+      fireEvent.click(closeButton);
+      
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('特殊ケース', () => {
+    it('cardNameが指定されている場合はそれが表示されること', () => {
+      const scheduleWithCustomCardName = {
+        ...mockScheduleItems[0],
+        cardName: 'カスタムカード名'
+      };
+      
+      render(<ScheduleModal 
+        {...defaultProps} 
+        scheduleItems={[scheduleWithCustomCardName]}
+      />);
+      
+      expect(screen.getByText('カスタムカード名')).toBeInTheDocument();
+    });
+
+    it('bankNameから銀行を特定できない場合の処理', () => {
+      const scheduleWithUnknownBank = {
+        ...mockScheduleItems[2],
+        bankName: '存在しない銀行'
+      };
+      
+      // エラーが発生せずに正常に動作することを確認
+      expect(() => {
+        render(<ScheduleModal 
+          {...defaultProps} 
+          scheduleItems={[scheduleWithUnknownBank]}
+        />);
+      }).not.toThrow();
+    });
+  });
+
+  describe('TypeScript型安全性', () => {
+    it('適切な型でpropsが渡されること', () => {
+      // このテストはコンパイル時に型チェックされるため、
+      // 主に型定義が正しく機能することの確認
+      expect(() => {
+        render(<ScheduleModal {...defaultProps} />);
+      }).not.toThrow();
+    });
+
+    it('無効なscheduleItemデータに対して堅牢であること', () => {
+      const invalidScheduleItem = {
+        ...mockScheduleItems[0],
+        cardId: 'non-existent-card'
+      };
+      
+      // 無効なカードIDでもエラーが発生しないことを確認
+      expect(() => {
+        render(<ScheduleModal 
+          {...defaultProps} 
+          scheduleItems={[invalidScheduleItem]}
+        />);
+      }).not.toThrow();
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('引落予定項目に編集不可であることが明確に示されること', () => {
+      const { container } = render(<ScheduleModal {...defaultProps} />);
+      
+      // クリック不可の項目にはcursor-pointerクラスがない
+      const scheduleItems = container.querySelectorAll('.px-4.py-3');
+      scheduleItems.forEach(item => {
+        expect(item).not.toHaveClass('cursor-pointer');
+      });
+    });
+  });
+});

--- a/__tests__/components/calendar/TransactionViewModal.test.tsx
+++ b/__tests__/components/calendar/TransactionViewModal.test.tsx
@@ -1,0 +1,409 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TransactionViewModal } from '@/components/calendar/TransactionViewModal';
+import { Transaction, Bank, Card } from '@/types/database';
+
+describe('TransactionViewModal', () => {
+  const mockBanks: Bank[] = [
+    {
+      id: 'bank-1',
+      name: 'SBIネット銀行',
+      memo: '',
+      createdAt: Date.now()
+    },
+    {
+      id: 'bank-2',
+      name: 'りそな銀行',
+      memo: '',
+      createdAt: Date.now()
+    }
+  ];
+
+  const mockCards: Card[] = [
+    {
+      id: 'card-1',
+      name: 'PayPayカード',
+      bankId: 'bank-1',
+      closingDay: '15',
+      paymentDay: '27',
+      paymentMonthShift: 1,
+      adjustWeekend: true,
+      memo: '',
+      createdAt: Date.now()
+    },
+    {
+      id: 'card-2',
+      name: '楽天カード',
+      bankId: 'bank-2',
+      closingDay: '月末',
+      paymentDay: '27',
+      paymentMonthShift: 1,
+      adjustWeekend: true,
+      memo: '',
+      createdAt: Date.now()
+    }
+  ];
+
+  const mockTransactions: Transaction[] = [
+    {
+      id: 'trans-1',
+      amount: 15000,
+      date: new Date(2024, 1, 15).getTime(),
+      storeName: 'Amazon',
+      paymentType: 'card',
+      cardId: 'card-1',
+      scheduledPayDate: new Date(2024, 2, 27).getTime(),
+      memo: '',
+      createdAt: Date.now()
+    },
+    {
+      id: 'trans-2',
+      amount: 22840,
+      date: new Date(2024, 1, 15).getTime(),
+      storeName: '楽天市場',
+      paymentType: 'card',
+      cardId: 'card-2',
+      scheduledPayDate: new Date(2024, 2, 27).getTime(),
+      memo: '',
+      createdAt: Date.now()
+    },
+    {
+      id: 'trans-3',
+      amount: 8000,
+      date: new Date(2024, 1, 15).getTime(),
+      storeName: '電気代',
+      paymentType: 'bank',
+      bankId: 'bank-1',
+      scheduledPayDate: new Date(2024, 1, 15).getTime(),
+      memo: '',
+      createdAt: Date.now()
+    }
+  ];
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    onTransactionClick: jest.fn(),
+    selectedDate: new Date(2024, 1, 15),
+    transactions: mockTransactions,
+    banks: mockBanks,
+    cards: mockCards
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('基本レンダリング', () => {
+    it('モーダルが正常に表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      expect(screen.getByText('取引データ - 2024年2月15日')).toBeInTheDocument();
+      expect(screen.getByText('取引データ')).toBeInTheDocument();
+      expect(screen.getByText('実際に行った支払い取引')).toBeInTheDocument();
+    });
+
+    it('isOpenがfalseのときにモーダルが表示されないこと', () => {
+      render(<TransactionViewModal {...defaultProps} isOpen={false} />);
+      
+      expect(screen.queryByText('取引データ - 2024年2月15日')).not.toBeInTheDocument();
+    });
+
+    it('取引データがないときにモーダルが表示されないこと', () => {
+      render(<TransactionViewModal {...defaultProps} transactions={[]} />);
+      
+      expect(screen.queryByText('取引データ - 2024年2月15日')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('緑色テーマの適用', () => {
+    it('ヘッダーが緑色背景で表示されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      const header = container.querySelector('.bg-green-50.border-green-200');
+      expect(header).toBeInTheDocument();
+    });
+
+    it('取引サマリーが緑色テーマで表示されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      const summary = container.querySelector('.bg-green-50.border-green-200');
+      expect(summary).toBeInTheDocument();
+      expect(summary?.textContent).toContain('取引データ');
+    });
+
+    it('銀行セクションヘッダーが緑色で表示されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      const bankHeaders = container.querySelectorAll('.bg-green-100.border-b.border-green-200');
+      expect(bankHeaders.length).toBeGreaterThan(0);
+    });
+
+    it('取引項目が緑色ボーダーで表示されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      const transactionItems = container.querySelectorAll('.border-green-200');
+      expect(transactionItems.length).toBeGreaterThan(0);
+    });
+
+    it('取引バッジが緑色で表示されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      const badges = container.querySelectorAll('.bg-green-100.text-green-800');
+      expect(badges.length).toBeGreaterThan(0);
+      
+      // 取引バッジが正しく表示されていることを確認
+      const transactionBadges = screen.getAllByText('取引');
+      expect(transactionBadges.length).toBe(3);
+    });
+  });
+
+  describe('取引データサマリー', () => {
+    it('正しい合計金額が表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      // 15,000 + 22,840 + 8,000 = 45,840
+      expect(screen.getByText('￥45,840')).toBeInTheDocument();
+    });
+
+    it('正しい取引件数が表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      expect(screen.getByText('3件の取引')).toBeInTheDocument();
+    });
+
+    it('取引データの説明文が表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      expect(screen.getByText('実際に行った支払い取引')).toBeInTheDocument();
+    });
+  });
+
+  describe('銀行別グループ化表示', () => {
+    it('銀行別にグループ化されて表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      expect(screen.getByText('SBIネット銀行')).toBeInTheDocument();
+      expect(screen.getByText('りそな銀行')).toBeInTheDocument();
+    });
+
+    it('銀行ごとの合計金額が正しく表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      // SBIネット銀行: PayPayカード(15,000) + 銀行引落(8,000) = 23,000
+      expect(screen.getByText('￥23,000')).toBeInTheDocument();
+      
+      // りそな銀行: 楽天カード(22,840) = 22,840 (重複があるため getAllByText を使用)
+      const amounts22840 = screen.getAllByText('￥22,840');
+      expect(amounts22840.length).toBeGreaterThan(0);
+    });
+
+    it('銀行ごとの取引件数が正しく表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      // SBIネット銀行は2件、りそな銀行は1件
+      const bankHeaders = screen.getAllByText(/\d+件/);
+      expect(bankHeaders.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('カード名と支払い方法表示', () => {
+    it('カード支払いでカード名が表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      expect(screen.getByText('PayPayカード')).toBeInTheDocument();
+      expect(screen.getByText('楽天カード')).toBeInTheDocument();
+    });
+
+    it('銀行引落で「自動引き落とし」が表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      expect(screen.getByText('自動引き落とし')).toBeInTheDocument();
+    });
+
+    it('すべての取引に「取引」バッジが表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      const badges = screen.getAllByText('取引');
+      expect(badges.length).toBe(3);
+    });
+  });
+
+  describe('店舗情報表示', () => {
+    it('店舗名が正しく表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      // 店舗名はカード名の右側に表示される（• 形式で）
+      expect(screen.getByText('• Amazon')).toBeInTheDocument();
+      expect(screen.getByText('• 楽天市場')).toBeInTheDocument();
+      expect(screen.getByText('• 電気代')).toBeInTheDocument();
+    });
+
+    it('カード名の右に店舗情報が表示されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      // カード名と店舗名が同じ行に表示されていることを確認
+      const cardNameElements = container.querySelectorAll('.font-medium.text-gray-900');
+      expect(cardNameElements.length).toBeGreaterThan(0);
+      
+      // 店舗情報が適切な位置に表示されることを確認
+      const storeInfoElements = screen.getAllByText(/• /);
+      expect(storeInfoElements.length).toBeGreaterThan(0);
+    });
+
+    it('店舗名がない取引でも正常に表示されること', () => {
+      const transactionWithoutStore = {
+        ...mockTransactions[0],
+        storeName: ''
+      };
+      
+      render(<TransactionViewModal 
+        {...defaultProps} 
+        transactions={[transactionWithoutStore]}
+      />);
+      
+      expect(screen.getByText('PayPayカード')).toBeInTheDocument();
+      // 店舗名がない場合は店舗情報セクションが表示されない
+      expect(screen.queryByText('店舗:')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('編集可能機能', () => {
+    it('取引項目がクリック可能であること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      const transactionItems = container.querySelectorAll('.cursor-pointer');
+      expect(transactionItems.length).toBeGreaterThan(0);
+    });
+
+    it('取引項目に編集アイコンが表示されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      // 編集アイコン（鉛筆アイコン）のパスを確認
+      const editIcons = container.querySelectorAll('path[d*="15.232 5.232l3.536 3.536"]');
+      expect(editIcons.length).toBe(3); // 3つの取引分
+    });
+
+    it('取引項目クリックでonTransactionClickが呼ばれること', async () => {
+      const onTransactionClick = jest.fn();
+      render(<TransactionViewModal 
+        {...defaultProps} 
+        onTransactionClick={onTransactionClick}
+      />);
+      
+      // PayPayカードの取引項目をクリック
+      const payPayCard = screen.getByText('PayPayカード');
+      const transactionRow = payPayCard.closest('.cursor-pointer');
+      fireEvent.click(transactionRow!);
+      
+      await waitFor(() => {
+        expect(onTransactionClick).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'trans-1',
+            storeName: 'Amazon'
+          })
+        );
+      });
+    });
+
+    it('ホバー効果が適用されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      const transactionItems = container.querySelectorAll('.hover\\:bg-green-50');
+      expect(transactionItems.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('操作ガイド', () => {
+    it('操作ガイドが表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      expect(screen.getByText('操作ガイド:')).toBeInTheDocument();
+      expect(screen.getByText('取引項目をクリックすると詳細編集ができます')).toBeInTheDocument();
+      expect(screen.getByText('店舗情報がある場合は項目に表示されます')).toBeInTheDocument();
+      expect(screen.getByText('編集モードでは取引の詳細を変更できます')).toBeInTheDocument();
+    });
+
+    it('操作ガイドに情報アイコンが表示されること', () => {
+      const { container } = render(<TransactionViewModal {...defaultProps} />);
+      
+      const infoIcon = container.querySelector('.text-blue-500');
+      expect(infoIcon).toBeInTheDocument();
+    });
+  });
+
+  describe('データが空の場合', () => {
+    it('取引データがない場合のメッセージが表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} transactions={[]} />);
+      
+      // 取引データがない場合はモーダル自体が表示されない
+      expect(screen.queryByText('この日の取引データはありません')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('個別金額表示', () => {
+    it('各取引の金額が正しく表示されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      expect(screen.getByText('￥15,000')).toBeInTheDocument();
+      // 22,840円は複数回表示される可能性があるため getAllByText を使用
+      const amounts22840 = screen.getAllByText('￥22,840');
+      expect(amounts22840.length).toBeGreaterThan(0);
+      expect(screen.getByText('￥8,000')).toBeInTheDocument();
+    });
+  });
+
+  describe('複数銀行の処理', () => {
+    it('異なる銀行のカードが正しくグループ化されること', () => {
+      render(<TransactionViewModal {...defaultProps} />);
+      
+      // 両方の銀行が表示される
+      expect(screen.getByText('SBIネット銀行')).toBeInTheDocument();
+      expect(screen.getByText('りそな銀行')).toBeInTheDocument();
+      
+      // 対応するカードが正しい銀行下に表示される
+      expect(screen.getByText('PayPayカード')).toBeInTheDocument();
+      expect(screen.getByText('楽天カード')).toBeInTheDocument();
+    });
+  });
+
+  describe('閉じる操作', () => {
+    it('フッターの閉じるボタンが正常に動作すること', async () => {
+      const onClose = jest.fn();
+      render(<TransactionViewModal {...defaultProps} onClose={onClose} />);
+      
+      const closeButton = screen.getByText('閉じる');
+      fireEvent.click(closeButton);
+      
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('TypeScript型安全性', () => {
+    it('適切な型でpropsが渡されること', () => {
+      // このテストはコンパイル時に型チェックされるため、
+      // 主に型定義が正しく機能することの確認
+      expect(() => {
+        render(<TransactionViewModal {...defaultProps} />);
+      }).not.toThrow();
+    });
+
+    it('無効なtransactionデータに対して堅牢であること', () => {
+      const invalidTransaction = {
+        ...mockTransactions[0],
+        cardId: 'non-existent-card'
+      };
+      
+      // 無効なカードIDでもエラーが発生しないことを確認
+      expect(() => {
+        render(<TransactionViewModal 
+          {...defaultProps} 
+          transactions={[invalidTransaction]}
+        />);
+      }).not.toThrow();
+    });
+  });
+});

--- a/__tests__/types/calendar-modal-integration.test.ts
+++ b/__tests__/types/calendar-modal-integration.test.ts
@@ -1,0 +1,434 @@
+/**
+ * 分離ダイアログ機能のTypeScript型安全性テスト
+ * 
+ * このテストファイルは、新しく実装された分離ダイアログ機能における
+ * TypeScript型の安全性と整合性を検証します。
+ */
+
+import { Transaction, ScheduleItem, Bank, Card } from '@/types/database';
+import { DayTotalData, BankGroup, DayTransactionItem } from '@/types/calendar';
+
+describe('分離ダイアログ機能の型安全性', () => {
+  
+  describe('BaseModal型定義', () => {
+    it('BaseModalPropsの型定義が正しく動作すること', () => {
+      // BaseModalPropsの型チェック
+      const validBaseModalProps = {
+        isOpen: true,
+        onClose: () => {},
+        title: 'テストタイトル',
+        children: 'テストコンテンツ',
+        size: 'md' as const,
+        className: 'test-class',
+        headerClassName: 'header-class',
+        bodyClassName: 'body-class',
+        footerChildren: 'フッターコンテンツ'
+      };
+      
+      // 型エラーが発生しないことを確認
+      expect(typeof validBaseModalProps.isOpen).toBe('boolean');
+      expect(typeof validBaseModalProps.onClose).toBe('function');
+      expect(typeof validBaseModalProps.title).toBe('string');
+    });
+
+    it('BaseModalFooterPropsの型定義が正しく動作すること', () => {
+      const validFooterProps = {
+        onClose: () => {},
+        primaryAction: {
+          label: '保存',
+          onClick: () => {},
+          variant: 'primary' as const,
+          disabled: false
+        },
+        secondaryAction: {
+          label: 'キャンセル',
+          onClick: () => {},
+          variant: 'secondary' as const,
+          disabled: false
+        }
+      };
+      
+      expect(typeof validFooterProps.primaryAction.label).toBe('string');
+      expect(typeof validFooterProps.primaryAction.onClick).toBe('function');
+      expect(validFooterProps.primaryAction.variant).toBe('primary');
+    });
+  });
+
+  describe('TransactionViewModal型定義', () => {
+    it('TransactionViewModalPropsの型定義が正しく動作すること', () => {
+      const mockBanks: Bank[] = [{
+        id: 'bank-1',
+        name: 'テスト銀行',
+        memo: '',
+        createdAt: Date.now()
+      }];
+
+      const mockCards: Card[] = [{
+        id: 'card-1',
+        name: 'テストカード',
+        bankId: 'bank-1',
+        closingDay: '15',
+        paymentDay: '27',
+        paymentMonthShift: 1,
+        adjustWeekend: true,
+        memo: '',
+        createdAt: Date.now()
+      }];
+
+      const mockTransactions: Transaction[] = [{
+        id: 'trans-1',
+        amount: 10000,
+        date: Date.now(),
+        storeName: 'テスト店舗',
+        paymentType: 'card',
+        cardId: 'card-1',
+        scheduledPayDate: Date.now(),
+        memo: '',
+        createdAt: Date.now()
+      }];
+
+      const validTransactionViewModalProps = {
+        isOpen: true,
+        onClose: () => {},
+        onTransactionClick: (transaction: Transaction) => {},
+        selectedDate: new Date(),
+        transactions: mockTransactions,
+        banks: mockBanks,
+        cards: mockCards,
+        className: 'test-class'
+      };
+
+      // 型エラーが発生しないことを確認
+      expect(Array.isArray(validTransactionViewModalProps.transactions)).toBe(true);
+      expect(Array.isArray(validTransactionViewModalProps.banks)).toBe(true);
+      expect(Array.isArray(validTransactionViewModalProps.cards)).toBe(true);
+      expect(validTransactionViewModalProps.selectedDate instanceof Date).toBe(true);
+    });
+
+    it('TransactionBankGroup型が正しく構造化されていること', () => {
+      const mockTransactionBankGroup = {
+        bankId: 'bank-1',
+        bankName: 'テスト銀行',
+        totalAmount: 10000,
+        transactionCount: 2,
+        items: [
+          {
+            id: 'trans-1',
+            amount: 5000,
+            paymentType: 'card' as const,
+            bankName: 'テスト銀行',
+            cardName: 'テストカード',
+            storeName: 'テスト店舗',
+            transaction: {} as Transaction
+          }
+        ]
+      };
+
+      expect(typeof mockTransactionBankGroup.bankId).toBe('string');
+      expect(typeof mockTransactionBankGroup.totalAmount).toBe('number');
+      expect(Array.isArray(mockTransactionBankGroup.items)).toBe(true);
+      expect(mockTransactionBankGroup.items[0].paymentType).toBe('card');
+    });
+  });
+
+  describe('ScheduleModal型定義', () => {
+    it('ScheduleModalPropsの型定義が正しく動作すること', () => {
+      const mockScheduleItems: ScheduleItem[] = [{
+        transactionId: 'schedule-1',
+        date: new Date(),
+        amount: 5000,
+        storeName: 'テスト店舗',
+        usage: 'テスト用途',
+        paymentType: 'card',
+        cardId: 'card-1',
+        cardName: 'テストカード',
+        bankName: 'テスト銀行'
+      }];
+
+      const validScheduleModalProps = {
+        isOpen: true,
+        onClose: () => {},
+        selectedDate: new Date(),
+        scheduleItems: mockScheduleItems,
+        banks: [] as Bank[],
+        cards: [] as Card[],
+        className: 'test-class'
+      };
+
+      expect(Array.isArray(validScheduleModalProps.scheduleItems)).toBe(true);
+      expect(validScheduleModalProps.selectedDate instanceof Date).toBe(true);
+      expect(typeof validScheduleModalProps.onClose).toBe('function');
+    });
+
+    it('ScheduleBankGroup型が正しく構造化されていること', () => {
+      const mockScheduleBankGroup = {
+        bankId: 'bank-1',
+        bankName: 'テスト銀行',
+        totalAmount: 15000,
+        scheduleCount: 3,
+        items: [
+          {
+            id: 'schedule-1',
+            amount: 5000,
+            paymentType: 'bank' as const,
+            bankName: 'テスト銀行',
+            cardName: '自動引き落とし',
+            storeName: 'テスト店舗',
+            usage: 'テスト用途',
+            scheduleItem: {} as ScheduleItem
+          }
+        ]
+      };
+
+      expect(typeof mockScheduleBankGroup.scheduleCount).toBe('number');
+      expect(mockScheduleBankGroup.items[0].paymentType).toBe('bank');
+      expect(typeof mockScheduleBankGroup.items[0].usage).toBe('string');
+    });
+  });
+
+  describe('CalendarView型定義', () => {
+    it('CalendarViewPropsの分離クリックハンドラーが正しく型定義されていること', () => {
+      const mockOnTransactionViewClick = (date: Date, transactions: Transaction[]) => {
+        expect(date instanceof Date).toBe(true);
+        expect(Array.isArray(transactions)).toBe(true);
+      };
+
+      const mockOnScheduleViewClick = (date: Date, scheduleItems: ScheduleItem[]) => {
+        expect(date instanceof Date).toBe(true);
+        expect(Array.isArray(scheduleItems)).toBe(true);
+      };
+
+      // 型チェック
+      expect(typeof mockOnTransactionViewClick).toBe('function');
+      expect(typeof mockOnScheduleViewClick).toBe('function');
+    });
+
+    it('CalendarViewの新しいpropsが正しく型定義されていること', () => {
+      const validCalendarViewProps = {
+        year: 2024,
+        month: 2,
+        transactions: [] as Transaction[],
+        schedule: undefined as any,
+        banks: [] as Bank[],
+        cards: [] as Card[],
+        onDateClick: (date: Date) => {},
+        onTransactionClick: (transaction: Transaction) => {},
+        onTransactionViewClick: (date: Date, transactions: Transaction[]) => {},
+        onScheduleViewClick: (date: Date, scheduleItems: ScheduleItem[]) => {},
+        onMonthChange: (year: number, month: number) => {},
+        className: 'test-class'
+      };
+
+      expect(typeof validCalendarViewProps.year).toBe('number');
+      expect(typeof validCalendarViewProps.month).toBe('number');
+      expect(typeof validCalendarViewProps.onTransactionViewClick).toBe('function');
+      expect(typeof validCalendarViewProps.onScheduleViewClick).toBe('function');
+    });
+  });
+
+  describe('Calendar型定義の統合', () => {
+    it('DayTotalData型が分離機能に対応していること', () => {
+      const mockDayTotalData: DayTotalData = {
+        date: '2024-02-15',
+        totalAmount: 50000,
+        transactionCount: 3,
+        scheduleCount: 2,
+        transactionTotal: 30000,
+        scheduleTotal: 20000,
+        bankGroups: [] as BankGroup[],
+        transactions: [] as Transaction[],
+        scheduleItems: [] as any[],
+        hasData: true,
+        hasTransactions: true,
+        hasSchedule: true
+      };
+
+      expect(typeof mockDayTotalData.transactionTotal).toBe('number');
+      expect(typeof mockDayTotalData.scheduleTotal).toBe('number');
+      expect(typeof mockDayTotalData.hasTransactions).toBe('boolean');
+      expect(typeof mockDayTotalData.hasSchedule).toBe('boolean');
+    });
+
+    it('DayTransactionItem型が取引と引落予定を区別できること', () => {
+      const transactionItem: DayTransactionItem = {
+        id: 'trans-1',
+        type: 'transaction',
+        amount: 10000,
+        paymentType: 'card',
+        bankName: 'テスト銀行',
+        cardName: 'テストカード',
+        storeName: 'テスト店舗',
+        transaction: {} as Transaction
+      };
+
+      const scheduleItem: DayTransactionItem = {
+        id: 'schedule-1',
+        type: 'schedule',
+        amount: 5000,
+        paymentType: 'bank',
+        bankName: 'テスト銀行',
+        cardName: '自動引き落とし',
+        scheduleItem: {} as ScheduleItem
+      };
+
+      expect(transactionItem.type).toBe('transaction');
+      expect(scheduleItem.type).toBe('schedule');
+      expect('transaction' in transactionItem).toBe(true);
+      expect('scheduleItem' in scheduleItem).toBe(true);
+    });
+
+    it('BankGroup型が銀行別グループ化に対応していること', () => {
+      const mockBankGroup: BankGroup = {
+        bankId: 'bank-1',
+        bankName: 'テスト銀行',
+        totalAmount: 25000,
+        transactionCount: 5,
+        items: [
+          {
+            id: 'item-1',
+            type: 'transaction',
+            amount: 15000,
+            paymentType: 'card',
+            bankName: 'テスト銀行',
+            cardName: 'テストカード',
+            transaction: {} as Transaction
+          },
+          {
+            id: 'item-2',
+            type: 'schedule',
+            amount: 10000,
+            paymentType: 'bank',
+            bankName: 'テスト銀行',
+            cardName: '自動引き落とし',
+            scheduleItem: {} as ScheduleItem
+          }
+        ]
+      };
+
+      expect(typeof mockBankGroup.bankId).toBe('string');
+      expect(typeof mockBankGroup.totalAmount).toBe('number');
+      expect(Array.isArray(mockBankGroup.items)).toBe(true);
+      expect(mockBankGroup.items[0].type).toBe('transaction');
+      expect(mockBankGroup.items[1].type).toBe('schedule');
+    });
+  });
+
+  describe('型安全性のエラーケース', () => {
+    it('無効な型を渡した場合のTypeScript型チェック', () => {
+      // この関数は実行時には呼ばれないが、TypeScriptのコンパイル時に型チェックが行われる
+      const testTypeChecking = () => {
+        // 正しい型の例
+        const validTransaction: Transaction = {
+          id: 'test',
+          amount: 1000,
+          date: Date.now(),
+          storeName: 'テスト',
+          paymentType: 'card',
+          cardId: 'card-1',
+          scheduledPayDate: Date.now(),
+          memo: '',
+          createdAt: Date.now()
+        };
+
+        const validScheduleItem: ScheduleItem = {
+          transactionId: 'test',
+          date: new Date(),
+          amount: 1000,
+          storeName: 'テスト',
+          paymentType: 'card',
+          bankName: 'テスト銀行'
+        };
+
+        // 型の整合性確認
+        expect(typeof validTransaction.amount).toBe('number');
+        expect(typeof validScheduleItem.amount).toBe('number');
+        expect(validScheduleItem.date instanceof Date).toBe(true);
+      };
+
+      expect(testTypeChecking).not.toThrow();
+    });
+
+    it('オプショナルプロパティの型安全性', () => {
+      // storeName, usage, cardIdなどのオプショナルプロパティのテスト
+      const scheduleWithOptionalProps: ScheduleItem = {
+        transactionId: 'test',
+        date: new Date(),
+        amount: 1000,
+        paymentType: 'bank',
+        bankName: 'テスト銀行'
+        // storeName, usage, cardId, cardNameは省略可能
+      };
+
+      const scheduleWithAllProps: ScheduleItem = {
+        transactionId: 'test',
+        date: new Date(),
+        amount: 1000,
+        storeName: 'テスト店舗',
+        usage: 'テスト用途',
+        paymentType: 'card',
+        cardId: 'card-1',
+        cardName: 'テストカード',
+        bankName: 'テスト銀行'
+      };
+
+      expect(typeof scheduleWithOptionalProps.amount).toBe('number');
+      expect(typeof scheduleWithAllProps.storeName).toBe('string');
+      expect(typeof scheduleWithAllProps.usage).toBe('string');
+    });
+  });
+
+  describe('モーダル間のデータ受け渡し型安全性', () => {
+    it('CalendarViewからTransactionViewModalへのデータ受け渡しが型安全であること', () => {
+      const mockTransactions: Transaction[] = [
+        {
+          id: 'trans-1',
+          amount: 10000,
+          date: Date.now(),
+          storeName: 'Amazon',
+          paymentType: 'card',
+          cardId: 'card-1',
+          scheduledPayDate: Date.now(),
+          memo: '',
+          createdAt: Date.now()
+        }
+      ];
+
+      const mockHandleTransactionViewClick = (date: Date, transactions: Transaction[]) => {
+        // TransactionViewModalに渡されるデータの型チェック
+        expect(date instanceof Date).toBe(true);
+        expect(Array.isArray(transactions)).toBe(true);
+        expect(transactions.every(t => typeof t.id === 'string')).toBe(true);
+        expect(transactions.every(t => typeof t.amount === 'number')).toBe(true);
+      };
+
+      mockHandleTransactionViewClick(new Date(), mockTransactions);
+    });
+
+    it('CalendarViewからScheduleModalへのデータ受け渡しが型安全であること', () => {
+      const mockScheduleItems: ScheduleItem[] = [
+        {
+          transactionId: 'schedule-1',
+          date: new Date(),
+          amount: 5000,
+          storeName: 'テスト店舗',
+          usage: 'テスト用途',
+          paymentType: 'card',
+          cardId: 'card-1',
+          cardName: 'テストカード',
+          bankName: 'テスト銀行'
+        }
+      ];
+
+      const mockHandleScheduleViewClick = (date: Date, scheduleItems: ScheduleItem[]) => {
+        // ScheduleModalに渡されるデータの型チェック
+        expect(date instanceof Date).toBe(true);
+        expect(Array.isArray(scheduleItems)).toBe(true);
+        expect(scheduleItems.every(s => typeof s.transactionId === 'string')).toBe(true);
+        expect(scheduleItems.every(s => typeof s.amount === 'number')).toBe(true);
+        expect(scheduleItems.every(s => s.date instanceof Date)).toBe(true);
+      };
+
+      mockHandleScheduleViewClick(new Date(), mockScheduleItems);
+    });
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import React, { useState } from 'react';
-import { CalendarView, MonthNavigation, TransactionModal, DayTotalModal } from '@/components/calendar';
+import { CalendarView, MonthNavigation, TransactionModal, TransactionViewModal, ScheduleModal } from '@/components/calendar';
 import { Navigation, NavigationIcons } from '@/components/ui';
 import { useBanks, useCards, useTransactions, useMonthlySchedule } from '@/lib/hooks/useDatabase';
-import { Transaction, TransactionInput } from '@/types/database';
-import { DayTotalData } from '@/types/calendar';
+import { Transaction, TransactionInput, ScheduleItem } from '@/types/database';
 import { getCurrentJapanDate } from '@/lib/utils/dateUtils';
 
 export default function CalendarPage() {
@@ -23,9 +22,13 @@ export default function CalendarPage() {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   
-  // Day total modal state
-  const [isDayTotalModalOpen, setIsDayTotalModalOpen] = useState(false);
-  const [selectedDayTotalData, setSelectedDayTotalData] = useState<DayTotalData | null>(null);
+  // Transaction view modal state
+  const [isTransactionViewModalOpen, setIsTransactionViewModalOpen] = useState(false);
+  const [selectedTransactions, setSelectedTransactions] = useState<Transaction[]>([]);
+  
+  // Schedule modal state
+  const [isScheduleModalOpen, setIsScheduleModalOpen] = useState(false);
+  const [selectedScheduleItems, setSelectedScheduleItems] = useState<ScheduleItem[]>([]);
 
   // Database hooks
   const { banks, isLoading: banksLoading, error: banksError } = useBanks();
@@ -87,17 +90,24 @@ export default function CalendarPage() {
     setIsModalOpen(true);
   };
 
-  // Handle day total click
-  const handleDayTotalClick = (date: Date, dayTotalData: DayTotalData) => {
+  // Handle transaction view click
+  const handleTransactionViewClick = (date: Date, transactions: Transaction[]) => {
     setSelectedDate(date);
-    setSelectedDayTotalData(dayTotalData);
-    setIsDayTotalModalOpen(true);
+    setSelectedTransactions(transactions);
+    setIsTransactionViewModalOpen(true);
   };
 
-  // Handle day total modal transaction click
-  const handleDayTotalTransactionClick = (transaction: Transaction) => {
-    // DayTotalModalを閉じてTransactionModalを開く
-    setIsDayTotalModalOpen(false);
+  // Handle schedule view click
+  const handleScheduleViewClick = (date: Date, scheduleItems: ScheduleItem[]) => {
+    setSelectedDate(date);
+    setSelectedScheduleItems(scheduleItems);
+    setIsScheduleModalOpen(true);
+  };
+
+  // Handle transaction view modal transaction click
+  const handleTransactionViewTransactionClick = (transaction: Transaction) => {
+    // TransactionViewModalを閉じてTransactionModalを開く
+    setIsTransactionViewModalOpen(false);
     setSelectedTransaction(transaction);
     setSelectedDate(new Date(transaction.date));
     setIsModalOpen(true);
@@ -136,10 +146,16 @@ export default function CalendarPage() {
     setSelectedTransaction(null);
   };
 
-  // Handle day total modal close
-  const handleDayTotalModalClose = () => {
-    setIsDayTotalModalOpen(false);
-    setSelectedDayTotalData(null);
+  // Handle transaction view modal close
+  const handleTransactionViewModalClose = () => {
+    setIsTransactionViewModalOpen(false);
+    setSelectedTransactions([]);
+  };
+
+  // Handle schedule modal close
+  const handleScheduleModalClose = () => {
+    setIsScheduleModalOpen(false);
+    setSelectedScheduleItems([]);
   };
 
   // Loading state
@@ -237,7 +253,8 @@ export default function CalendarPage() {
                 cards={cards}
                 onDateClick={handleDateClick}
                 onTransactionClick={handleTransactionClick}
-                onDayTotalClick={handleDayTotalClick}
+                onTransactionViewClick={handleTransactionViewClick}
+                onScheduleViewClick={handleScheduleViewClick}
                 onMonthChange={handleMonthChange}
               />
             )}
@@ -259,14 +276,26 @@ export default function CalendarPage() {
         />
       )}
 
-      {/* Day total modal */}
-      {isDayTotalModalOpen && selectedDate && selectedDayTotalData && (
-        <DayTotalModal
-          isOpen={isDayTotalModalOpen}
-          onClose={handleDayTotalModalClose}
-          onTransactionClick={handleDayTotalTransactionClick}
+      {/* Transaction view modal */}
+      {isTransactionViewModalOpen && selectedDate && selectedTransactions.length > 0 && (
+        <TransactionViewModal
+          isOpen={isTransactionViewModalOpen}
+          onClose={handleTransactionViewModalClose}
+          onTransactionClick={handleTransactionViewTransactionClick}
           selectedDate={selectedDate}
-          dayTotalData={selectedDayTotalData}
+          transactions={selectedTransactions}
+          banks={banks}
+          cards={cards}
+        />
+      )}
+
+      {/* Schedule modal */}
+      {isScheduleModalOpen && selectedDate && selectedScheduleItems.length > 0 && (
+        <ScheduleModal
+          isOpen={isScheduleModalOpen}
+          onClose={handleScheduleModalClose}
+          selectedDate={selectedDate}
+          scheduleItems={selectedScheduleItems}
           banks={banks}
           cards={cards}
         />

--- a/src/components/calendar/BaseModal.tsx
+++ b/src/components/calendar/BaseModal.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface BaseModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string | undefined;
+  headerClassName?: string;
+  bodyClassName?: string;
+  footerChildren?: React.ReactNode;
+}
+
+/**
+ * BaseModal - 共通モーダル基盤コンポーネント
+ * 
+ * 設計原則:
+ * - 再利用可能な基盤構造
+ * - TypeScript完全対応
+ * - アクセシビリティ準拠
+ * - エラーハンドリング対応
+ */
+export function BaseModal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  size = 'md',
+  className,
+  headerClassName,
+  bodyClassName,
+  footerChildren,
+}: BaseModalProps) {
+  // Escキー押下でモーダルを閉じる
+  React.useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      // モーダル表示時はボディのスクロールを無効化
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, onClose]);
+
+  // モーダルが開いていない場合は何も表示しない
+  if (!isOpen) return null;
+
+  // バックドロップクリックでモーダルを閉じる
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  // サイズによるクラス設定
+  const sizeClasses = {
+    sm: 'max-w-sm',
+    md: 'max-w-md',
+    lg: 'max-w-lg'
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+    >
+      <div className={cn(
+        'bg-white rounded-lg shadow-xl w-full mx-4 max-h-[90vh] overflow-hidden',
+        'transform transition-all duration-200 ease-in-out',
+        sizeClasses[size],
+        className
+      )}>
+        {/* ヘッダー */}
+        <div className={cn(
+          'px-6 py-4 border-b border-gray-200',
+          headerClassName
+        )}>
+          <div className="flex items-center justify-between">
+            <h2 
+              id="modal-title"
+              className="text-lg font-semibold text-gray-900"
+            >
+              {title}
+            </h2>
+            <button
+              onClick={onClose}
+              className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="閉じる"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* ボディ */}
+        <div className={cn(
+          'overflow-y-auto',
+          bodyClassName
+        )}>
+          {children}
+        </div>
+
+        {/* フッター（オプション） */}
+        {footerChildren && (
+          <div className="px-6 py-4 border-t border-gray-200 bg-gray-50">
+            {footerChildren}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 共通フッターコンポーネント
+ */
+export interface BaseModalFooterProps {
+  onClose: () => void;
+  primaryAction?: {
+    label: string;
+    onClick: () => void;
+    variant?: 'primary' | 'secondary' | 'danger';
+    disabled?: boolean;
+  };
+  secondaryAction?: {
+    label: string;
+    onClick: () => void;
+    variant?: 'secondary' | 'ghost';
+    disabled?: boolean;
+  };
+}
+
+export function BaseModalFooter({
+  onClose,
+  primaryAction,
+  secondaryAction
+}: BaseModalFooterProps) {
+  const getButtonClasses = (variant: string = 'secondary', disabled: boolean = false) => {
+    const baseClasses = 'px-4 py-2 rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
+    
+    if (disabled) {
+      return cn(baseClasses, 'bg-gray-300 text-gray-500 cursor-not-allowed');
+    }
+    
+    switch (variant) {
+      case 'primary':
+        return cn(baseClasses, 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500');
+      case 'danger':
+        return cn(baseClasses, 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500');
+      case 'ghost':
+        return cn(baseClasses, 'text-gray-600 hover:text-gray-800 hover:bg-gray-100 focus:ring-gray-500');
+      default: // secondary
+        return cn(baseClasses, 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500');
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-end space-x-3">
+      {secondaryAction && (
+        <button
+          onClick={secondaryAction.onClick}
+          disabled={secondaryAction.disabled}
+          className={getButtonClasses(secondaryAction.variant, secondaryAction.disabled)}
+        >
+          {secondaryAction.label}
+        </button>
+      )}
+      
+      {primaryAction ? (
+        <button
+          onClick={primaryAction.onClick}
+          disabled={primaryAction.disabled}
+          className={getButtonClasses(primaryAction.variant, primaryAction.disabled)}
+        >
+          {primaryAction.label}
+        </button>
+      ) : (
+        <button
+          onClick={onClose}
+          className={getButtonClasses('secondary')}
+        >
+          閉じる
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -25,7 +25,8 @@ export interface CalendarViewProps {
   cards: Card[];
   onDateClick: (date: Date) => void;
   onTransactionClick: (transaction: Transaction) => void;
-  onDayTotalClick?: (date: Date, dayTotalData: DayTotalData) => void;
+  onTransactionViewClick?: (date: Date, transactions: Transaction[]) => void;
+  onScheduleViewClick?: (date: Date, scheduleItems: any[]) => void;
   onMonthChange?: (year: number, month: number) => void;
   className?: string;
 }
@@ -39,7 +40,8 @@ export function CalendarView({
   cards: _cards,
   onDateClick,
   onTransactionClick: _onTransactionClick,
-  onDayTotalClick,
+  onTransactionViewClick,
+  onScheduleViewClick,
   onMonthChange,
   className
 }: CalendarViewProps) {
@@ -159,16 +161,29 @@ export function CalendarView({
     onDateClick(calendarDay.date);
   };
 
-  const handleDayTotalClick = (calendarDay: CalendarDay, e: React.MouseEvent) => {
+  const handleTransactionClick = (calendarDay: CalendarDay, e: React.MouseEvent) => {
     e.stopPropagation(); // 日付クリックとは別のイベントとして処理
     
-    if (!calendarDay.date || !onDayTotalClick) return;
+    if (!calendarDay.date || !onTransactionViewClick) return;
     
     const dateKey = formatDateISO(calendarDay.date);
     const dayTotal = calculateDayTotals.get(dateKey);
     
-    if (dayTotal && dayTotal.hasData) {
-      onDayTotalClick(calendarDay.date, dayTotal);
+    if (dayTotal && dayTotal.hasTransactions) {
+      onTransactionViewClick(calendarDay.date, dayTotal.transactions);
+    }
+  };
+
+  const handleScheduleClick = (calendarDay: CalendarDay, e: React.MouseEvent) => {
+    e.stopPropagation(); // 日付クリックとは別のイベントとして処理
+    
+    if (!calendarDay.date || !onScheduleViewClick) return;
+    
+    const dateKey = formatDateISO(calendarDay.date);
+    const dayTotal = calculateDayTotals.get(dateKey);
+    
+    if (dayTotal && dayTotal.hasSchedule) {
+      onScheduleViewClick(calendarDay.date, dayTotal.scheduleItems);
     }
   };
 
@@ -266,7 +281,7 @@ export function CalendarView({
                       <div 
                         key="transaction"
                         className="px-2 py-1 text-xs rounded cursor-pointer bg-green-100 text-green-900 hover:bg-green-200 border border-green-300 font-semibold"
-                        onClick={(e) => handleDayTotalClick(calendarDay, e)}
+                        onClick={(e) => handleTransactionClick(calendarDay, e)}
                         title={`取引合計: ${formatAmount(dayTotal.transactionTotal)} (取引${dayTotal.transactionCount}件)`}
                       >
                         <div className="text-center">
@@ -283,7 +298,7 @@ export function CalendarView({
                       <div 
                         key="schedule"
                         className="px-2 py-1 text-xs rounded cursor-pointer bg-blue-100 text-blue-900 hover:bg-blue-200 border border-blue-300 font-semibold"
-                        onClick={(e) => handleDayTotalClick(calendarDay, e)}
+                        onClick={(e) => handleScheduleClick(calendarDay, e)}
                         title={`引落予定合計: ${formatAmount(dayTotal.scheduleTotal)} (予定${dayTotal.scheduleCount}件)`}
                       >
                         <div className="text-center">

--- a/src/components/calendar/DayTotalModal.tsx
+++ b/src/components/calendar/DayTotalModal.tsx
@@ -209,11 +209,6 @@ export function DayTotalModal({
                     引落予定合計: <span className="font-bold text-blue-600">{formatAmount(dayTotalData.scheduleTotal)}</span>
                   </p>
                 )}
-                {dayTotalData.hasTransactions && dayTotalData.hasSchedule && (
-                  <p>
-                    総合計: <span className="font-bold text-gray-900">{formatAmount(dayTotalData.totalAmount)}</span>
-                  </p>
-                )}
               </div>
             </div>
             <button

--- a/src/components/calendar/ScheduleModal.tsx
+++ b/src/components/calendar/ScheduleModal.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import React from 'react';
+import { formatAmount } from '@/lib/utils/validation';
+import { formatJapaneseDate } from '@/lib/utils/dateUtils';
+import { ScheduleItem, Bank, Card } from '@/types/database';
+import { BaseModal, BaseModalFooter } from './BaseModal';
+
+export interface ScheduleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  selectedDate: Date;
+  scheduleItems: ScheduleItem[];
+  banks: Bank[];
+  cards: Card[];
+  className?: string;
+}
+
+/**
+ * 銀行別グループ化された引落予定データ
+ */
+interface ScheduleBankGroup {
+  bankId: string;
+  bankName: string;
+  totalAmount: number;
+  scheduleCount: number;
+  items: {
+    id: string;
+    amount: number;
+    paymentType: 'card' | 'bank';
+    bankName: string;
+    cardName: string;
+    storeName?: string;
+    usage?: string;
+    scheduleItem: ScheduleItem;
+  }[];
+}
+
+/**
+ * 引落予定データの銀行別グループ化
+ */
+function groupSchedulesByBank(
+  scheduleItems: ScheduleItem[],
+  banks: Bank[],
+  cards: Card[]
+): ScheduleBankGroup[] {
+  const bankMap = new Map<string, Bank>();
+  const cardMap = new Map<string, Card>();
+  
+  banks.forEach(bank => bankMap.set(bank.id, bank));
+  cards.forEach(card => cardMap.set(card.id, card));
+  
+  const bankGroups = new Map<string, ScheduleBankGroup>();
+  
+  scheduleItems.forEach(scheduleItem => {
+    let bankId: string;
+    let bankName: string;
+    let displayName: string;
+    
+    if (scheduleItem.paymentType === 'card' && scheduleItem.cardId) {
+      const card = cardMap.get(scheduleItem.cardId);
+      if (!card) return;
+      
+      bankId = card.bankId;
+      const bank = bankMap.get(bankId);
+      if (!bank) return;
+      
+      bankName = bank.name;
+      displayName = scheduleItem.cardName || card.name;
+    } else if (scheduleItem.paymentType === 'bank') {
+      // スケジュールアイテムの場合、bankNameから銀行を特定
+      const bank = banks.find(b => b.name === scheduleItem.bankName);
+      if (!bank) return;
+      
+      bankId = bank.id;
+      bankName = bank.name;
+      displayName = '自動引き落とし';
+    } else {
+      return;
+    }
+    
+    if (!bankGroups.has(bankId)) {
+      bankGroups.set(bankId, {
+        bankId,
+        bankName,
+        totalAmount: 0,
+        scheduleCount: 0,
+        items: []
+      });
+    }
+    
+    const group = bankGroups.get(bankId)!;
+    group.totalAmount += scheduleItem.amount;
+    group.scheduleCount++;
+    
+    group.items.push({
+      id: scheduleItem.transactionId,
+      amount: scheduleItem.amount,
+      paymentType: scheduleItem.paymentType,
+      bankName,
+      cardName: displayName,
+      ...(scheduleItem.storeName && { storeName: scheduleItem.storeName }),
+      ...(scheduleItem.usage && { usage: scheduleItem.usage }),
+      scheduleItem
+    });
+  });
+  
+  return Array.from(bankGroups.values()).sort((a, b) => a.bankName.localeCompare(b.bankName));
+}
+
+/**
+ * ScheduleModal - 引落予定専用モーダル
+ * 
+ * 特徴:
+ * - 青色テーマ
+ * - 表示のみ（編集不可）
+ * - 銀行別グループ化表示
+ * - 店舗情報表示
+ */
+export function ScheduleModal({
+  isOpen,
+  onClose,
+  selectedDate,
+  scheduleItems,
+  banks,
+  cards,
+  className
+}: ScheduleModalProps) {
+  if (!isOpen || scheduleItems.length === 0) return null;
+
+  // 引落予定データを銀行別にグループ化
+  const bankGroups = groupSchedulesByBank(scheduleItems, banks, cards);
+  
+  // 総合計算
+  const totalAmount = scheduleItems.reduce((sum, item) => sum + item.amount, 0);
+  const totalCount = scheduleItems.length;
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`引落予定 - ${formatJapaneseDate(selectedDate)}`}
+      size="lg"
+      className={className || undefined}
+      headerClassName="bg-blue-50 border-blue-200"
+      bodyClassName="max-h-[60vh]"
+      footerChildren={
+        <BaseModalFooter 
+          onClose={onClose}
+        />
+      }
+    >
+      <div className="p-6 space-y-6">
+        {/* 引落予定サマリー */}
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-blue-800 mb-1">
+                引落予定
+              </h3>
+              <p className="text-sm text-blue-700">
+                予定されている引落し
+              </p>
+            </div>
+            <div className="text-right">
+              <div className="text-2xl font-bold text-blue-800">
+                {formatAmount(totalAmount)}
+              </div>
+              <div className="text-sm text-blue-600">
+                {totalCount}件の予定
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* データがない場合 */}
+        {bankGroups.length === 0 ? (
+          <div className="text-center py-8">
+            <p className="text-gray-500">この日の引落予定はありません</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* 銀行別グループ表示 */}
+            {bankGroups.map(bankGroup => (
+              <div
+                key={bankGroup.bankId}
+                className="bg-white border border-blue-200 rounded-lg overflow-hidden shadow-sm"
+              >
+                {/* 銀行セクションヘッダー */}
+                <div className="px-4 py-3 bg-blue-100 border-b border-blue-200">
+                  <div className="flex items-center justify-between">
+                    <h4 className="font-semibold text-blue-900">
+                      {bankGroup.bankName}
+                    </h4>
+                    <div className="text-right">
+                      <div className="font-bold text-blue-900">
+                        {formatAmount(bankGroup.totalAmount)}
+                      </div>
+                      <div className="text-sm text-blue-700">
+                        {bankGroup.scheduleCount}件
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                
+                {/* 引落予定項目一覧 */}
+                <div className="divide-y divide-blue-100">
+                  {bankGroup.items.map(item => (
+                    <div
+                      key={item.id}
+                      className="px-4 py-3 flex items-center justify-between bg-white hover:bg-blue-25 transition-colors"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center space-x-3">
+                          <div className="flex-1">
+                            <div className="flex items-center space-x-2 mb-1">
+                              <span className="font-medium text-gray-900">
+                                {item.cardName}
+                              </span>
+                              {item.storeName && (
+                                <span className="text-gray-600 text-sm">
+                                  • {item.storeName}
+                                </span>
+                              )}
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                                予定
+                              </span>
+                            </div>
+                            
+                            {/* 店舗情報と用途を表示 */}
+                            <div className="space-y-1">
+                              {item.storeName && (
+                                <p className="text-sm text-gray-600">
+                                  <span className="font-medium">店舗:</span> {item.storeName}
+                                </p>
+                              )}
+                              {item.usage && (
+                                <p className="text-sm text-gray-600">
+                                  <span className="font-medium">用途:</span> {item.usage}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center space-x-3">
+                        <span className="font-bold text-gray-900">
+                          {formatAmount(item.amount)}
+                        </span>
+                        {/* 表示のみなので編集アイコンは不要 */}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* 情報ガイド */}
+        {bankGroups.length > 0 && (
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+            <div className="flex items-start space-x-2">
+              <svg className="w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div className="text-sm text-gray-600">
+                <p className="font-medium mb-1">引落予定について:</p>
+                <ul className="list-disc list-inside space-y-1">
+                  <li>これらは取引に基づいて自動計算された引落予定です</li>
+                  <li>実際の引落日は銀行の営業日により前後する場合があります</li>
+                  <li>店舗情報と用途が登録されている場合に表示されます</li>
+                  <li>引落予定は表示のみで、直接編集はできません</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/components/calendar/TransactionViewModal.tsx
+++ b/src/components/calendar/TransactionViewModal.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import React from 'react';
+import { formatAmount } from '@/lib/utils/validation';
+import { formatJapaneseDate } from '@/lib/utils/dateUtils';
+import { Transaction, Bank, Card } from '@/types/database';
+import { BaseModal, BaseModalFooter } from './BaseModal';
+
+export interface TransactionViewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onTransactionClick: (transaction: Transaction) => void;
+  selectedDate: Date;
+  transactions: Transaction[];
+  banks: Bank[];
+  cards: Card[];
+  className?: string;
+}
+
+/**
+ * 銀行別グループ化された取引データ
+ */
+interface TransactionBankGroup {
+  bankId: string;
+  bankName: string;
+  totalAmount: number;
+  transactionCount: number;
+  items: {
+    id: string;
+    amount: number;
+    paymentType: 'card' | 'bank';
+    bankName: string;
+    cardName: string;
+    storeName?: string;
+    transaction: Transaction;
+  }[];
+}
+
+/**
+ * 取引データの銀行別グループ化
+ */
+function groupTransactionsByBank(
+  transactions: Transaction[],
+  banks: Bank[],
+  cards: Card[]
+): TransactionBankGroup[] {
+  const bankMap = new Map<string, Bank>();
+  const cardMap = new Map<string, Card>();
+  
+  banks.forEach(bank => bankMap.set(bank.id, bank));
+  cards.forEach(card => cardMap.set(card.id, card));
+  
+  const bankGroups = new Map<string, TransactionBankGroup>();
+  
+  transactions.forEach(transaction => {
+    let bankId: string;
+    let bankName: string;
+    let displayName: string;
+    
+    if (transaction.paymentType === 'card' && transaction.cardId) {
+      const card = cardMap.get(transaction.cardId);
+      if (!card) return;
+      
+      bankId = card.bankId;
+      const bank = bankMap.get(bankId);
+      if (!bank) return;
+      
+      bankName = bank.name;
+      displayName = card.name;
+    } else if (transaction.paymentType === 'bank' && transaction.bankId) {
+      bankId = transaction.bankId;
+      const bank = bankMap.get(bankId);
+      if (!bank) return;
+      
+      bankName = bank.name;
+      displayName = '自動引き落とし';
+    } else {
+      return;
+    }
+    
+    if (!bankGroups.has(bankId)) {
+      bankGroups.set(bankId, {
+        bankId,
+        bankName,
+        totalAmount: 0,
+        transactionCount: 0,
+        items: []
+      });
+    }
+    
+    const group = bankGroups.get(bankId)!;
+    group.totalAmount += transaction.amount;
+    group.transactionCount++;
+    
+    group.items.push({
+      id: transaction.id,
+      amount: transaction.amount,
+      paymentType: transaction.paymentType,
+      bankName,
+      cardName: displayName,
+      ...(transaction.storeName && { storeName: transaction.storeName }),
+      transaction
+    });
+  });
+  
+  return Array.from(bankGroups.values()).sort((a, b) => a.bankName.localeCompare(b.bankName));
+}
+
+/**
+ * TransactionViewModal - 取引専用モーダル
+ * 
+ * 特徴:
+ * - 緑色テーマ
+ * - 編集可能（取引クリックで編集モーダル表示）
+ * - 銀行別グループ化表示
+ * - 店舗情報表示
+ */
+export function TransactionViewModal({
+  isOpen,
+  onClose,
+  onTransactionClick,
+  selectedDate,
+  transactions,
+  banks,
+  cards,
+  className
+}: TransactionViewModalProps) {
+  if (!isOpen || transactions.length === 0) return null;
+
+  // 取引データを銀行別にグループ化
+  const bankGroups = groupTransactionsByBank(transactions, banks, cards);
+  
+  // 総合計算
+  const totalAmount = transactions.reduce((sum, transaction) => sum + transaction.amount, 0);
+  const totalCount = transactions.length;
+
+  const handleTransactionClick = (transaction: Transaction) => {
+    onTransactionClick(transaction);
+    // モーダルは開いたままにして、編集モーダルを上に表示
+  };
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`取引データ - ${formatJapaneseDate(selectedDate)}`}
+      size="lg"
+      className={className || undefined}
+      headerClassName="bg-green-50 border-green-200"
+      bodyClassName="max-h-[60vh]"
+      footerChildren={
+        <BaseModalFooter 
+          onClose={onClose}
+        />
+      }
+    >
+      <div className="p-6 space-y-6">
+        {/* 取引サマリー */}
+        <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-green-800 mb-1">
+                取引データ
+              </h3>
+              <p className="text-sm text-green-700">
+                実際に行った支払い取引
+              </p>
+            </div>
+            <div className="text-right">
+              <div className="text-2xl font-bold text-green-800">
+                {formatAmount(totalAmount)}
+              </div>
+              <div className="text-sm text-green-600">
+                {totalCount}件の取引
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* データがない場合 */}
+        {bankGroups.length === 0 ? (
+          <div className="text-center py-8">
+            <p className="text-gray-500">この日の取引データはありません</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* 銀行別グループ表示 */}
+            {bankGroups.map(bankGroup => (
+              <div
+                key={bankGroup.bankId}
+                className="bg-white border border-green-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow"
+              >
+                {/* 銀行セクションヘッダー */}
+                <div className="px-4 py-3 bg-green-100 border-b border-green-200">
+                  <div className="flex items-center justify-between">
+                    <h4 className="font-semibold text-green-900">
+                      {bankGroup.bankName}
+                    </h4>
+                    <div className="text-right">
+                      <div className="font-bold text-green-900">
+                        {formatAmount(bankGroup.totalAmount)}
+                      </div>
+                      <div className="text-sm text-green-700">
+                        {bankGroup.transactionCount}件
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                
+                {/* 取引項目一覧 */}
+                <div className="divide-y divide-green-100">
+                  {bankGroup.items.map(item => (
+                    <div
+                      key={item.id}
+                      onClick={() => handleTransactionClick(item.transaction)}
+                      className="px-4 py-3 flex items-center justify-between hover:bg-green-50 cursor-pointer transition-colors group"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center space-x-3">
+                          <div className="flex-1">
+                            <div className="flex items-center space-x-2">
+                              <span className="font-medium text-gray-900">
+                                {item.cardName}
+                              </span>
+                              {item.storeName && (
+                                <span className="text-gray-600 text-sm">
+                                  • {item.storeName}
+                                </span>
+                              )}
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                                取引
+                              </span>
+                            </div>
+                            {item.storeName && (
+                              <p className="text-sm text-gray-600 truncate mt-1">
+                                店舗: {item.storeName}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center space-x-3">
+                        <span className="font-bold text-gray-900">
+                          {formatAmount(item.amount)}
+                        </span>
+                        <svg 
+                          className="w-4 h-4 text-green-600 group-hover:text-green-700 transition-colors" 
+                          fill="none" 
+                          stroke="currentColor" 
+                          viewBox="0 0 24 24"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                        </svg>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* 操作ガイド */}
+        {bankGroups.length > 0 && (
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+            <div className="flex items-start space-x-2">
+              <svg className="w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div className="text-sm text-gray-600">
+                <p className="font-medium mb-1">操作ガイド:</p>
+                <ul className="list-disc list-inside space-y-1">
+                  <li>取引項目をクリックすると詳細編集ができます</li>
+                  <li>店舗情報がある場合は項目に表示されます</li>
+                  <li>編集モードでは取引の詳細を変更できます</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -7,4 +7,7 @@
 
 export { CalendarView, MonthNavigation, type CalendarViewProps, type MonthNavigationProps } from './CalendarView';
 export { TransactionModal, type TransactionModalProps } from './TransactionModal';
+export { TransactionViewModal, type TransactionViewModalProps } from './TransactionViewModal';
+export { ScheduleModal, type ScheduleModalProps } from './ScheduleModal';
+export { BaseModal, BaseModalFooter, type BaseModalProps, type BaseModalFooterProps } from './BaseModal';
 export { DayTotalModal, type DayTotalModalProps } from './DayTotalModal';


### PR DESCRIPTION
- 取引データと引落予定データの表示ロジックを分離し、クリックイベントを追加
- CalendarViewでの取引と引落予定のクリックハンドラーを実装
- DayTotalModalから総合計の表示を削除し、個別表示に対応
- テストコードを更新し、新しい機能に対応

Subprojectのコミットを更新し、状態を「dirty」に変更。